### PR TITLE
Fix links in email

### DIFF
--- a/app/views/mailers/email_notification.text.erb
+++ b/app/views/mailers/email_notification.text.erb
@@ -5,7 +5,10 @@ I am happy to report that this monumental event has just happened!
 
 Check it out: <%= url_for @notifiable %>
 
-If you find RailsBump useful and would like to support the ongoing development, <%= link_to "buy me a coffee", "https://www.buymeacoffee.com/279lcDtbF" %> or <%= link_to "become a sponsor", "https://github.com/sponsors/manuelmeurer" %>!
+If you find RailsBump useful and would like to support the ongoing development you got several options:
+
+* Buy me a coffee: https://www.buymeacoffee.com/279lcDtbF
+* Become a sponsor: https://github.com/sponsors/manuelmeurer
 
 Bye for now,
 Your faithful RailsBump bot

--- a/app/views/mailers/email_notification.text.erb
+++ b/app/views/mailers/email_notification.text.erb
@@ -5,7 +5,7 @@ I am happy to report that this monumental event has just happened!
 
 Check it out: <%= url_for @notifiable %>
 
-If you find RailsBump useful and would like to support the ongoing development you got several options:
+If you find RailsBump useful and would like to support the ongoing development, you have several options:
 
 * Buy me a coffee: https://www.buymeacoffee.com/279lcDtbF
 * Become a sponsor: https://github.com/sponsors/manuelmeurer


### PR DESCRIPTION
This fix email (in Gmail) like on this screenshot:
![image](https://user-images.githubusercontent.com/668524/153444046-94b69fba-f00c-4d23-94b7-53e450c3eb97.png)


Plain text emails cannot show links with `<a>` tag correctly

So I think there are two choices:
1. Replace plan text email with HTML one (a little bit complicated)
2. Just insert a plain link, like in other parts of this email

I've chosen a second option