### PR TITLE
Better error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,49 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <title>RailsBump - Page Not Found</title>
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+  <link href='/assets/icons/android-chrome-192x192-bcc11136.png' rel='icon' sizes='192x192' type='image/png'>
+  <link href='/assets/icons/android-chrome-512x512-f33ab1a0.png' rel='icon' sizes='512x512' type='image/png'>
+  <link href='/assets/icons/favicon-16x16-21aed9a0.png' rel='icon' sizes='16x16' type='image/png'>
+  <link href='/assets/icons/favicon-32x32-c4ab590a.png' rel='icon' sizes='32x32' type='image/png'>
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
+  <meta charset='utf-8'>
+  <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
+  <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
+  <meta content='width=device-width,initial-scale=1' name='viewport'>
+  <link rel="stylesheet" href="/assets/application-06b90193.css" data-turbo-track="reload" media="all" />
 </head>
+<body class=''>
+  <header>
+    <nav class="navbar navbar-dark bg-dark navbar-expand-md">
+      <div class="container-lg">
+        <a href="/" class="navbar-brand">👊 RailsBump</a>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapsable" aria-controls="navbar-collapsable" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <li class="nav-item">
+          <a href="https://github.com/railsbump/app" target="_blank" class="nav-link">
+            <i class="fab fa-github"></i>
+          </a>
+        </li>
+      </div>
+    </nav>
+  </header>
+
+  <main class='container-lg'>
+    <section>
+      <div class='row'>
+        <div class='col-md-8 col-xl-9'>
+          <h1>404 - Page Not Found</h1>
+          <p>Sorry, the page you are looking for does not exist.</p>
+          <p><a href="https://github.com/railsbump/app/issues/new" target="_blank">Submit a new issue on GitHub</a></p>
+          <p><a href="/">Return Home</a></p>
+        </div>
+      </div>
+    </section>
+  </main>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,67 +1,49 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The change you wanted was rejected (422)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <title>RailsBump - Unprocessable Entity</title>
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+  <link href='/assets/icons/android-chrome-192x192-bcc11136.png' rel='icon' sizes='192x192' type='image/png'>
+  <link href='/assets/icons/android-chrome-512x512-f33ab1a0.png' rel='icon' sizes='512x512' type='image/png'>
+  <link href='/assets/icons/favicon-16x16-21aed9a0.png' rel='icon' sizes='16x16' type='image/png'>
+  <link href='/assets/icons/favicon-32x32-c4ab590a.png' rel='icon' sizes='32x32' type='image/png'>
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
+  <meta charset='utf-8'>
+  <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
+  <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
+  <meta content='width=device-width,initial-scale=1' name='viewport'>
+  <link rel="stylesheet" href="/assets/application-06b90193.css" data-turbo-track="reload" media="all" />
 </head>
+<body class=''>
+  <header>
+    <nav class="navbar navbar-dark bg-dark navbar-expand-md">
+      <div class="container-lg">
+        <a href="/" class="navbar-brand">👊 RailsBump</a>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapsable" aria-controls="navbar-collapsable" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <li class="nav-item">
+          <a href="https://github.com/railsbump/app" target="_blank" class="nav-link">
+            <i class="fab fa-github"></i>
+          </a>
+        </li>
+      </div>
+    </nav>
+  </header>
+
+  <main class='container-lg'>
+    <section>
+      <div class='row'>
+        <div class='col-md-8 col-xl-9'>
+          <h1>422 - Unprocessable Entity</h1>
+          <p>Sorry, we couldn't process your request. Please check your input and try again.</p>
+          <p><a href="https://github.com/railsbump/app/issues/new" target="_blank">Submit a new issue on GitHub</a></p>
+          <p><a href="/">Return Home</a></p>
+        </div>
+      </div>
+    </section>
+  </main>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,49 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <title>RailsBump - Internal Server Error</title>
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+  <link href='/assets/icons/android-chrome-192x192-bcc11136.png' rel='icon' sizes='192x192' type='image/png'>
+  <link href='/assets/icons/android-chrome-512x512-f33ab1a0.png' rel='icon' sizes='512x512' type='image/png'>
+  <link href='/assets/icons/favicon-16x16-21aed9a0.png' rel='icon' sizes='16x16' type='image/png'>
+  <link href='/assets/icons/favicon-32x32-c4ab590a.png' rel='icon' sizes='32x32' type='image/png'>
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
+  <meta charset='utf-8'>
+  <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
+  <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
+  <meta content='width=device-width,initial-scale=1' name='viewport'>
+  <link rel="stylesheet" href="/assets/application-06b90193.css" data-turbo-track="reload" media="all" />
 </head>
+<body class=''>
+  <header>
+    <nav class="navbar navbar-dark bg-dark navbar-expand-md">
+      <div class="container-lg">
+        <a href="/" class="navbar-brand">👊 RailsBump</a>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-collapsable" aria-controls="navbar-collapsable" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <li class="nav-item">
+          <a href="https://github.com/railsbump/app" target="_blank" class="nav-link">
+            <i class="fab fa-github"></i>
+          </a>
+        </li>
+      </div>
+    </nav>
+  </header>
+
+  <main class='container-lg'>
+    <section>
+      <div class='row'>
+        <div class='col-md-8 col-xl-9'>
+          <h1>500 - Internal Server Error</h1>
+          <p>Sorry, something went wrong on our end. Please try again later.</p>
+          <p><a href="https://github.com/railsbump/app/issues/new" target="_blank">Submit a new issue on GitHub</a></p>
+          <p><a href="/">Return Home</a></p>
+        </div>
+      </div>
+    </section>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
Hi there,

This fixes #35. The pages will look quite simple, but I still think it's an improvement... 

## 422 
<img width="797" alt="Screenshot 2024-10-13 at 9 06 06 PM" src="https://github.com/user-attachments/assets/d4b90f19-a6be-4523-a620-fdbc935d3d3e">

## 500

<img width="607" alt="Screenshot 2024-10-13 at 9 06 13 PM" src="https://github.com/user-attachments/assets/a8e1b7d9-7a8b-4f04-b7b5-2a046abca6de">

## 404 

<img width="686" alt="Screenshot 2024-10-13 at 9 06 20 PM" src="https://github.com/user-attachments/assets/23ae1b38-5ecf-4f0e-afc2-8e23ced4bfbd">

Please check it out.

Thanks! 