### PR TITLE
Remove rails-erd gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :development do
   gem "annotaterb",                             "~> 4.4", require: false
   gem "better_errors",                          "~> 2.8"
   gem "binding_of_caller",                      "~> 1.0"
-  gem "rails-erd",                              "~> 1.7.2"
 end
 
 # Run against this stable release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,6 @@ GEM
       gem_config (~> 0.3)
     builder (3.3.0)
     byebug (11.1.3)
-    choice (0.2.0)
     codecov (0.2.12)
       json
       simplecov
@@ -315,11 +314,6 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-erd (1.7.2)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
@@ -368,8 +362,6 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
-    ruby-graphviz (1.2.5)
-      rexml
     rufus-scheduler (3.9.1)
       fugit (~> 1.1, >= 1.1.6)
     sass-embedded (1.77.8-arm64-darwin)
@@ -475,7 +467,6 @@ DEPENDENCIES
   puma (~> 6.4)
   rails (~> 7.1.3.4)
   rails-controller-testing
-  rails-erd (~> 1.7.2)
   rails-i18n (~> 7.0)
   rails_bootstrap_navbar (~> 3.0)
   redis (~> 5.0)


### PR DESCRIPTION
The gem was installed on this PR https://github.com/railsbump/app/pull/116/files,
however, it seems to not being used anymore, would you want me to remove it?

Or we can configure it to generate the diagram on CI or so...

BTW, this is the how the diagram [erd.pdf](https://github.com/user-attachments/files/21150306/erd.pdf) currently looks like.
