### PR TITLE
Added rails-erd dependency to the dev group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
   gem "annotaterb",                             "~> 4.4", require: false
   gem "better_errors",                          "~> 2.8"
   gem "binding_of_caller",                      "~> 1.0"
+  gem "rails-erd"
 end
 
 # Run against this stable release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
       gem_config (~> 0.3)
     builder (3.3.0)
     byebug (11.1.3)
+    choice (0.2.0)
     codecov (0.2.12)
       json
       simplecov
@@ -337,6 +338,11 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
+    rails-erd (1.7.2)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
@@ -388,6 +394,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.1)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby2_keywords (0.0.5)
     rufus-scheduler (3.9.1)
       fugit (~> 1.1, >= 1.1.6)
@@ -502,6 +510,7 @@ DEPENDENCIES
   puma (~> 6.4)
   rails (~> 8.0.0)
   rails-controller-testing
+  rails-erd
   rails-i18n (~> 8.0.0)
   rails_bootstrap_navbar (~> 3.0)
   redis (~> 5.0)


### PR DESCRIPTION
Hi there,

This PR fixes this issue: 

```
➜  app git:(main) ✗ bundle exec rake db:create
rake aborted!
NameError: uninitialized constant RailsERD (NameError)

  RailsERD.load_tasks
  ^^^^^^^^
/Users/etagwerker/Projects/railsbump/app/lib/tasks/auto_generate_diagram.rake:5:in `<main>'
/Users/etagwerker/Projects/railsbump/app/Rakefile:5:in `<top (required)>'
/Users/etagwerker/.rbenv/versions/3.3.3/bin/bundle:25:in `load'
/Users/etagwerker/.rbenv/versions/3.3.3/bin/bundle:25:in `<main>'
(See full trace by running task with --trace)
```

Please check it out.

Thanks! 