### PR TITLE
Remove raise message

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,9 +53,6 @@ Rails.application.configure do
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
-  if Rails.version > "7.1.4"
-    raise "enable multiple loggers when this bug is fixed: https://github.com/rails/rails/issues/49745"
-  end
   # Log to STDOUT and production.log.
   # config.logger = [STDOUT, "log/production.log"].map do |destination|
   #   ActiveSupport::Logger.new(destination, formatter: ::Logger::Formatter.new)


### PR DESCRIPTION
The deployment failed; part of the message is referring to this change

I do not know why it failed now if Ernesto deployed earlier today. but anyways we are currently in Rails 8 and message was for Rails 7.1.4.

I do not see a good reason why that was added in the commits it was added in.
* https://github.com/railsbump/app/commit/a295da9f6bf42f2675526677615e360c3b661b08
* https://github.com/railsbump/app/commit/d885567f722e344c9569cc2873ca74fa45378d0c
* https://github.com/rails/rails/issues/49745

probably, safe to just remove it?