### PR TITLE
Adds Rails release data for Rails 8.1

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -17,6 +17,7 @@ namespace :data do
     7.1
     7.2
     8.0
+    8.1
   )
 
   task find_or_create_rails_releases: :environment do
@@ -126,7 +127,14 @@ namespace :data do
         minimum_bundler_version: "2.5.20",
         maximum_bundler_version: "2.5.20",
         minimum_rubygems_version: "3.2.3"
-       }
+       },
+       "8.1" => {
+        minimum_ruby_version: "3.2.0",
+        maximum_ruby_version: "3.4.8",
+        minimum_bundler_version: "1.15.0",
+        maximum_bundler_version: "2.5.20",
+        minimum_rubygems_version: "1.8.11"
+      }
     }
 
     min_versions.each do |version, attrs|


### PR DESCRIPTION
This PR fixes issue #137.

We are getting this error in Sentry:

```
Octokit::UnprocessableEntity: POST https://api.github.com/repos/railsbump/checker/actions/workflows/check_bundler.yml/dispatches: 422 - Required input 'bundler_version' not provided // See: https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event (Octokit::UnprocessableEntity)
  app/services/compats/checks/bundler_github_check.rb:21:in `check!'
```

We are missing data surrounding Rails 8.1 in production, which is causing this issue. This PR adds the missing data to the Rake task.

