### PR TITLE
Add Ruby 8.1 release data

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -18,7 +18,7 @@ namespace :data do
     7.2
     8.0
     8.1
-)
+  )
 
   task find_or_create_rails_releases: :environment do
     SUPPORTED_RAILS_VERSIONS.each do |version|


### PR DESCRIPTION
This just supersedes #138. But it's the same set of changes.

Fixes #137 