### PR TITLE
Fix Coverband auth and clean up config

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -2,8 +2,9 @@ Coverband.configure do |config|
   config.store = Coverband::Adapters::RedisStore.new(
     Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
   )
-  config.track_views = true
+  config.logger = Rails.logger
   config.background_reporting_enabled = true
   config.web_enable_clear = true
   config.ignore = %w[config/boot.rb config/environment.rb config/puma.rb bin/]
+  config.password = ENV["COVERBAND_PASSWORD"]
 end

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -3,6 +3,7 @@ Coverband.configure do |config|
     Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
   )
   config.logger = Rails.logger
+  config.track_views = true
   config.background_reporting_enabled = true
   config.web_enable_clear = true
   config.ignore = %w[config/boot.rb config/environment.rb config/puma.rb bin/]

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -6,5 +6,5 @@ Coverband.configure do |config|
   config.background_reporting_enabled = true
   config.web_enable_clear = true
   config.ignore = %w[config/boot.rb config/environment.rb config/puma.rb bin/]
-  config.password = ENV["COVERBAND_PASSWORD"]
+  config.password = ENV.fetch("COVERBAND_PASSWORD") if Rails.env.production?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 require "sidekiq/web"
 require "sidekiq-scheduler/web"
-require "coverband"
-
 if Rails.env.production?
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     {
@@ -12,22 +10,9 @@ if Rails.env.production?
   end
 end
 
-coverband_app = Rack::Builder.new do
-  if Rails.env.production?
-    use Rack::Auth::Basic do |username, password|
-      {
-        username => "COVERBAND_USERNAME",
-        password => "COVERBAND_PASSWORD"
-      }.map { ActiveSupport::SecurityUtils.secure_compare _1, ENV.fetch(_2) }
-       .all?
-    end
-  end
-  run Coverband::Reporters::Web.new
-end
-
 Rails.application.routes.draw do
   mount Sidekiq::Web => "sidekiq"
-  mount coverband_app, at: "/coverband"
+  mount Coverband::Reporters::Web.new, at: "/coverband"
 
   get '/sitemap.xml', to: 'sitemaps#show'
   get "/robots.txt" => "static#robots"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,19 +10,24 @@ if Rails.env.production?
     }.map { ActiveSupport::SecurityUtils.secure_compare _1, ENV.fetch(_2) }
      .all?
   end
+end
 
-  Coverband::Reporters::Web.use Rack::Auth::Basic do |username, password|
-    {
-      username => "COVERBAND_USERNAME",
-      password => "COVERBAND_PASSWORD"
-    }.map { ActiveSupport::SecurityUtils.secure_compare _1, ENV.fetch(_2) }
-     .all?
+coverband_app = Rack::Builder.new do
+  if Rails.env.production?
+    use Rack::Auth::Basic do |username, password|
+      {
+        username => "COVERBAND_USERNAME",
+        password => "COVERBAND_PASSWORD"
+      }.map { ActiveSupport::SecurityUtils.secure_compare _1, ENV.fetch(_2) }
+       .all?
+    end
   end
+  run Coverband::Reporters::Web.new
 end
 
 Rails.application.routes.draw do
   mount Sidekiq::Web => "sidekiq"
-  mount Coverband::Reporters::Web.new, at: "/coverband"
+  mount coverband_app, at: "/coverband"
 
   get '/sitemap.xml', to: 'sitemaps#show'
   get "/robots.txt" => "static#robots"


### PR DESCRIPTION
## Summary

- Fix `NoMethodError` on `Coverband::Reporters::Web.use` (it's a plain Rack app, not Sinatra)
- Use Coverband's built-in `config.password` for auth instead of a custom Rack middleware wrapper
- Require `COVERBAND_PASSWORD` env var in production (app crashes on boot if missing, preventing open access)
- Move config from `config/initializers/coverband.rb` to `config/coverband.rb` per Coverband docs
- Add `config.logger = Rails.logger`
- Remove unnecessary `require "coverband"` from routes (Railtie handles it)