### PR TITLE
Limit compat creation to latest major Rails versions

### DIFF
--- a/app/services/gemmies/update_compats.rb
+++ b/app/services/gemmies/update_compats.rb
@@ -7,7 +7,7 @@ module Gemmies
 
       gemmy = Gemmy.find gemmy_id
 
-      RailsRelease.find_each do |rails_release|
+      RailsRelease.latest_major.find_each do |rails_release|
         gemmy.dependencies.each do |dependencies|
           unless rails_release.compats.where("dependencies::jsonb = ?", dependencies.to_json).exists?
             rails_release.compats.create! dependencies: dependencies

--- a/spec/services/gemmies/process_spec.rb
+++ b/spec/services/gemmies/process_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Gemmies::Process, type: :service, vcr: { record: :once } do
     let(:service) { described_class.new }
 
     before do
-      FactoryBot.create(:rails_release, version: "7.1")
       FactoryBot.create(:rails_release, version: "7.2")
+      FactoryBot.create(:rails_release, version: "8.0")
 
       allow(Compats::CheckUnchecked).to receive(:perform_async)
 


### PR DESCRIPTION
## Summary

- Scope `UpdateCompats` to only create compats for `RailsRelease.latest_major` instead of all Rails versions

## Context

`UpdateCompats` was creating compats for all 17 Rails versions (2.3 through 8.1), but `CheckUnchecked` only processes the 2 latest major versions (currently 7.2 and 8.1). This mismatch means ~88% of new compats were created knowing they would never be checked, sitting as "pending" forever.

**By the numbers (from production, 2026-04-13):**

| Metric | Value |
|--------|-------|
| Total compats | 1,478,565 |
| Pending (never checked) | 351,898 (23.8%) |
| Compats per lockfile (84 gems x 17 versions) | ~1,428 |
| Compats per lockfile after this change (84 gems x 2 versions) | ~168 |
| Avg queue wait time (2026) | 8.9 days |

15 out of 17 Rails versions have not had a single compat checked in months or over a year:

| Version group | Last checked | Why it stopped |
|---------------|-------------|----------------|
| Rails 2.3-6.1 | 2025-04-02 | Fell out of `latest_major` when 8.x was added |
| Rails 7.0-7.1 | 2024-10-09 | Fell out when 7.2 was added |
| Rails 8.0 | 2025-10-22 | Fell out when 8.1 was added |
| Rails 7.2 | 2026-03-30 | Active |
| Rails 8.1 | 2026-04-14 | Active |

## What this changes

One line in `Gemmies::UpdateCompats`: `RailsRelease.find_each` becomes `RailsRelease.latest_major.find_each`.

New compats will only be created for actively checked versions. Existing compats for old versions remain untouched (they are still associated with gemmies via the `compat_ids` array, so old results continue to display).

## Test plan

- [ ] Verify `RailsRelease.latest_major` returns expected versions in production (currently 7.2 and 8.1)
- [ ] Submit a new lockfile and confirm compats are only created for latest major versions
- [ ] Confirm old lockfile reports still display results for all Rails versions (existing compats are not affected)
