### PR TITLE
Fix deploy process and staging environment errors

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails assets:precompile && bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
-release: bin/rails db:migrate assets:precompile
+release: bin/rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails assets:precompile && bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
-release: bin/rails assets:precompile && bundle exec rake sitemap:create
+release: bin/rails assets:precompile

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails assets:precompile && bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
-release: bin/rails assets:precompile
+release: bin/rails db:migrate assets:precompile

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -7,5 +7,5 @@ Coverband.configure do |config|
   config.background_reporting_enabled = true
   config.web_enable_clear = true
   config.ignore = %w[config/boot.rb config/environment.rb config/puma.rb bin/]
-  config.password = ENV.fetch("COVERBAND_PASSWORD") if Rails.env.production?
+  config.password = ENV["COVERBAND_PASSWORD"] if ENV["COVERBAND_PASSWORD"].present?
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,4 +1,4 @@
-unless Rails.env.local?
+if ENV["AWS_ACCESS_KEY_ID"].present?
   require "fog-aws"
 
   SitemapGenerator::Sitemap.default_host = "https://www.railsbump.org"


### PR DESCRIPTION
## Summary

- Fix staging deploy failures caused by missing AWS and Coverband credentials
- Clean up release phase: remove redundant sitemap generation and asset precompilation, add database migrations

## Changes

- `config/sitemap.rb`: Guard S3 adapter config on AWS credential presence instead of environment name
- `config/coverband.rb`: Use `ENV["COVERBAND_PASSWORD"]` with presence check instead of `ENV.fetch`, which raises during Heroku's rake task detection before Rails environment is resolved
- `Procfile`: Remove `rake sitemap:create` (already handled hourly by `Maintenance::Hourly`), remove `assets:precompile` (already handled by Heroku buildpack), add `db:migrate`

## Test plan

- [ ] Deploy to staging without AWS/Coverband credentials, verify no errors
- [ ] Verify sitemap still regenerates hourly via Sidekiq
- [ ] Verify migrations run during release phase

Closes #171, #172