### PR TITLE
Disable Coverband on staging

### DIFF
--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,11 +1,13 @@
-Coverband.configure do |config|
-  config.store = Coverband::Adapters::RedisStore.new(
-    Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
-  )
-  config.logger = Rails.logger
-  config.track_views = true
-  config.background_reporting_enabled = true
-  config.web_enable_clear = true
-  config.ignore = %w[config/boot.rb config/environment.rb config/puma.rb bin/]
-  config.password = ENV["COVERBAND_PASSWORD"] if ENV["COVERBAND_PASSWORD"].present?
+if ENV["COVERBAND_PASSWORD"].present?
+  Coverband.configure do |config|
+    config.store = Coverband::Adapters::RedisStore.new(
+      Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
+    )
+    config.logger = Rails.logger
+    config.track_views = true
+    config.background_reporting_enabled = true
+    config.web_enable_clear = true
+    config.ignore = %w[config/boot.rb config/environment.rb config/puma.rb bin/]
+    config.password = ENV["COVERBAND_PASSWORD"]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ end
 
 Rails.application.routes.draw do
   mount Sidekiq::Web => "sidekiq"
-  mount Coverband::Reporters::Web.new, at: "/coverband"
+  mount Coverband::Reporters::Web.new, at: "/coverband" if ENV["COVERBAND_PASSWORD"].present?
 
   get '/sitemap.xml', to: 'sitemaps#show'
   get "/robots.txt" => "static#robots"


### PR DESCRIPTION
## Summary

- Disable Coverband entirely on environments without `COVERBAND_PASSWORD` set
- Reduces Redis connection usage on staging, fixing SSL handshake failures caused by exceeding Heroku's connection limit

## Context

Staging uses Heroku's mini Redis plan (20 max connections). With Sidekiq, Rails cache store, ActionCable, Kredis, and Coverband all opening their own Redis connections, the total exceeded the limit. When Redis rejects new connections, the SSL handshake gets dropped mid-negotiation, producing `OpenSSL::SSL::SSLError: unexpected eof while reading` across all Redis clients.

Coverband is only needed in production for code coverage tracking. Disabling it on staging (where `COVERBAND_PASSWORD` is not set) frees up Redis connections. Combined with reducing `SIDEKIQ_CONCURRENCY` to 8, this brings connection usage well under the limit.

## Changes

- `config/coverband.rb`: Wrap entire configuration in `COVERBAND_PASSWORD` presence check
- `config/routes.rb`: Conditionally mount Coverband web UI only when password is configured

## Test plan

- [ ] Deploy to staging, verify no more Redis SSL errors in logs
- [ ] Verify Coverband still works in production (has `COVERBAND_PASSWORD` set)
- [ ] Check `heroku-redis` metrics show connections under limit