### PR TITLE
Fix DirectResolver Bundler API compat

### DIFF
--- a/lib/direct_resolver.rb
+++ b/lib/direct_resolver.rb
@@ -76,6 +76,14 @@ class DirectResolver
     earliest: -> { EarliestVersionPromoter.new }
   }.freeze
 
+  # Bundler API changed between 2.5.x and newer versions:
+  # - Resolver.new gained a third argument
+  # - Resolver::Package gained :prefer_local and :new_platforms kwargs
+  # - :unlock changed from Array to Boolean
+  RESOLVER_ACCEPTS_THIRD_ARG = Bundler::Resolver.instance_method(:initialize).arity.abs > 2
+  PACKAGE_SUPPORTS_PREFER_LOCAL = Bundler::Resolver::Package
+    .instance_method(:initialize).parameters.map(&:last).include?(:prefer_local)
+
   def initialize(
     rails_version:,
     ruby_version:,
@@ -99,7 +107,9 @@ class DirectResolver
   def call
     Bundler.with_unbundled_env do
       Bundler.ui.silence do
-        specs = Bundler::Resolver.new(resolution_base, gem_version_promoter, nil).start
+        resolver_args = [resolution_base, gem_version_promoter]
+        resolver_args << nil if RESOLVER_ACCEPTS_THIRD_ARG
+        specs = Bundler::Resolver.new(*resolver_args).start
         versions = specs.each_with_object({}) { |s, h| h[s.name] = s.version.to_s }
         Result.new(compatible?: true, specs: versions)
       end
@@ -111,16 +121,23 @@ class DirectResolver
   private
 
   def resolution_base
+    options = {
+      locked_specs: Bundler::SpecSet.new([]),
+      unlock: PACKAGE_SUPPORTS_PREFER_LOCAL ? true : [],
+      prerelease: gem_version_promoter.pre?
+    }
+
+    if PACKAGE_SUPPORTS_PREFER_LOCAL
+      options[:prefer_local] = false
+      options[:new_platforms] = []
+    end
+
     Bundler::Resolver::Base.new(
       source_requirements,
       expanded_dependencies,
       Bundler::SpecSet.new([]),
       [@runtime.local_platform],
-      locked_specs: Bundler::SpecSet.new([]),
-      unlock: true,
-      prerelease: gem_version_promoter.pre?,
-      prefer_local: false,
-      new_platforms: []
+      **options
     )
   end
 


### PR DESCRIPTION
## Summary

Related to #157

- Fix DirectResolver crashing on every gem resolution due to Bundler API incompatibilities
- All gems were incorrectly marked as "incompatible" on staging because the subprocess exited non-zero

## Context

DirectResolver was written against a newer Bundler API than the installed 2.5.13. Three breaking differences caused the `bin/resolve_gem` subprocess to crash before reaching the actual resolution logic:

1. **`Bundler::Resolver.new`** accepts 2 arguments in 2.5.13 but the code passed 3 (an extra `nil`)
2. **`Bundler::Resolver::Package#initialize`** gained `:prefer_local` and `:new_platforms` keyword arguments in newer versions. Bundler 2.5.13 raises `ArgumentError: unknown keywords` on them
3. **`:unlock` parameter** changed from `Array` (2.5.13 calls `.empty?` on it) to `Boolean` in newer versions

The error messages were masked because stderr was filled with Bundler constant redefinition warnings, pushing the actual crash message past the 1000-char truncation in `ResolveGem`.

## Changes

- `lib/direct_resolver.rb`: Add two class-level constants that detect Bundler's API at load time via reflection, then adapt the `Resolver.new` call and `Resolver::Base.new` kwargs accordingly. This supports both Bundler 2.5.x and newer versions without hardcoding version checks.

## Test plan

- [ ] `echo '{"rails_version":"8.1","ruby_version":"3.4.2","rubygems_version":"3.6.2","bundler_version":"2.5.20","dependencies":{"amazing_print":">= 1.6.0"},"promoter":"earliest"}' | ruby bin/resolve_gem` returns `{"compatible":true,...}`
- [ ] Deploy to staging, upload a lockfile, verify gems resolve as compatible/incompatible correctly
- [ ] Verify on production (once Bundler is upgraded) the constants detect the newer API