### PR TITLE
Bump Bundler from 2.5.13 to 4.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,7 +492,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 4.0.2p0
+  ruby 4.0.2p0
 
 BUNDLED WITH
-   2.5.13
+  4.0.10

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -497,7 +497,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 4.0.2p0
+  ruby 4.0.2p0
 
 BUNDLED WITH
-   2.5.13
+  4.0.10


### PR DESCRIPTION
## Summary

- Upgrade Bundler from 2.5.13 to 4.0.10 to fix DirectResolver gem resolution failures

## Context

DirectResolver uses Bundler's internal resolver APIs (`Bundler::Resolver`, `Bundler::Resolver::Base`, `Bundler::Resolver::Package`) which changed between 2.5.x and newer versions. With Bundler 2.5.13, the `bin/resolve_gem` subprocess crashes on every invocation due to API mismatches (wrong arity, unknown kwargs, type changes), causing all gems to be incorrectly marked as incompatible.

Upgrading Bundler aligns the runtime with the API that DirectResolver was written against.

Related: #178 (alternative fix using runtime reflection for backward compatibility)

## Changes

- `Gemfile.lock`: Bundler 2.5.13 -> 4.0.10
- `Gemfile.next.lock`: Bundler 2.5.13 -> 4.0.10

## Test plan

- [ ] `echo '{"rails_version":"8.1","ruby_version":"3.4.2","rubygems_version":"3.6.2","bundler_version":"2.5.20","dependencies":{"amazing_print":">= 1.6.0"},"promoter":"earliest"}' | ruby bin/resolve_gem` returns `{"compatible":true,...}`
- [ ] `bundle exec rspec` passes
- [ ] Deploy to staging, upload a lockfile, verify gems resolve correctly