### PR TITLE
Add data-driven tests for DirectResolver

### DIFF
--- a/spec/lib/direct_resolver_eval_spec.rb
+++ b/spec/lib/direct_resolver_eval_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Evaluation suite for DirectResolver. Runs real resolution against rubygems.org
+# using scenarios defined in direct_resolver_scenarios.yml.
+#
+# These are non-deterministic: gem releases can change resolution results.
+# A failure means "review what changed", not necessarily "code is broken."
+#
+# Run:    bundle exec rspec spec/lib/direct_resolver_eval_spec.rb
+# Update: EVAL_UPDATE=1 bundle exec rspec spec/lib/direct_resolver_eval_spec.rb
+#         (updates the YAML with current results for any mismatches)
+
+SCENARIOS_PATH = Rails.root.join("spec/lib/direct_resolver_scenarios.yml")
+
+RSpec.describe "DirectResolver evaluation", :network do
+  scenarios = YAML.safe_load_file(SCENARIOS_PATH, permitted_classes: [Symbol])
+
+  scenarios.each do |scenario|
+    describe scenario["name"] do
+      it "is #{scenario['expected']}" do
+        result = DirectResolver.new(
+          rails_version: scenario["rails_version"],
+          ruby_version: scenario["ruby_version"],
+          dependencies: scenario.fetch("dependencies", {}),
+          promoter: (scenario["promoter"] || "latest").to_sym
+        ).call
+
+        actual = result.compatible? ? "compatible" : "incompatible"
+
+        if actual != scenario["expected"] && ENV["EVAL_UPDATE"]
+          update_scenario(scenario["name"], actual)
+          pending "Result changed from #{scenario['expected']} to #{actual} (YAML updated)"
+        end
+
+        expect(actual).to eq(scenario["expected"]),
+          "Expected #{scenario['expected']} but got #{actual}.\n" \
+          "Error: #{result.error}\n" \
+          "Notes: #{scenario['notes']}\n" \
+          "Run with EVAL_UPDATE=1 to update the scenario file."
+      end
+    end
+  end
+end
+
+def update_scenario(name, new_expected)
+  content = File.read(SCENARIOS_PATH)
+  updated = false
+
+  lines = content.lines
+  lines.each_with_index do |line, i|
+    if line.strip == "- name: \"#{name}\""
+      # Find the expected: line within the next 10 lines
+      ((i + 1)..[i + 10, lines.length - 1].min).each do |j|
+        if lines[j].match?(/^\s+expected:/)
+          lines[j] = lines[j].sub(/expected:\s*\S+/, "expected: #{new_expected}")
+          updated = true
+          break
+        end
+      end
+    end
+  end
+
+  File.write(SCENARIOS_PATH, lines.join) if updated
+end

--- a/spec/lib/direct_resolver_scenarios.yml
+++ b/spec/lib/direct_resolver_scenarios.yml
@@ -1,0 +1,84 @@
+# DirectResolver evaluation scenarios.
+#
+# These are NOT deterministic tests. Gem ecosystems evolve, so a scenario
+# marked compatible today could become incompatible if a gem yanks a version
+# or changes its dependency constraints. Failures mean "review what changed",
+# not "code is broken."
+#
+# Run with: bundle exec rspec spec/lib/direct_resolver_eval_spec.rb
+# Update with: EVAL_UPDATE=1 bundle exec rspec spec/lib/direct_resolver_eval_spec.rb
+#
+# Fields:
+#   name:           human-readable label
+#   rails_version:  target Rails major.minor
+#   ruby_version:   target Ruby version
+#   dependencies:   hash of gem_name => version_constraint
+#   promoter:       latest (default) or earliest
+#   expected:       compatible or incompatible
+#   notes:          why we expect this result
+
+- name: "rack with Rails 8.0"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies:
+    rack: ">= 2.0"
+  expected: compatible
+  notes: "rack is a Rails dependency, wide constraint should always resolve"
+
+- name: "devise with Rails 8.0"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies:
+    devise: ">= 4.9.0"
+  expected: compatible
+  notes: "devise 4.9+ supports Rails 7+, should resolve with Rails 8"
+
+- name: "sidekiq with Rails 8.0"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies:
+    sidekiq: ">= 7.0"
+  expected: compatible
+  notes: "sidekiq 7+ is Rails 7+ compatible"
+
+- name: "multiple gems with Rails 8.0"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies:
+    devise: ">= 4.9.0"
+    sidekiq: ">= 7.0"
+  expected: compatible
+  notes: "common production stack"
+
+- name: "just Rails 8.0 (no extra deps)"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies: {}
+  expected: compatible
+  notes: "baseline: Rails alone must resolve"
+
+- name: "activesupport < 6.0 conflicts with Rails 8.0"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies:
+    activesupport: "< 6.0"
+  expected: incompatible
+  notes: "activesupport is a Rails sub-gem, pinning to < 6 conflicts with Rails 8"
+
+- name: "conflicting Rails pin"
+  rails_version: "8.0"
+  ruby_version: "3.4.2"
+  dependencies:
+    rails: "= 5.0.0"
+    rack: "= 1.0.0"
+  expected: incompatible
+  notes: "explicit conflict: Rails 5 + rack 1 cannot satisfy ~> 8.0.0"
+
+- name: "Rails 7.2 with devise (earliest)"
+  rails_version: "7.2"
+  ruby_version: "3.3.0"
+  dependencies:
+    devise: ">= 4.9.0"
+  promoter: earliest
+  expected: compatible
+  notes: "earliest promoter should still find a solution"


### PR DESCRIPTION
## Summary

Data-driven eval suite for `DirectResolver`. Scenarios in `direct_resolver_scenarios.yml` run real Bundler resolution against the RubyGems API. Failures mean "review what changed", not "code is broken."

- Run: `bundle exec rspec spec/lib/direct_resolver_eval_spec.rb`
- Update expectations: `EVAL_UPDATE=1 bundle exec rspec spec/lib/direct_resolver_eval_spec.rb`

8 scenarios: rack/devise/sidekiq with Rails 8, multi-gem, empty deps, conflicting constraints, earliest promoter with Rails 7.2.

Unit tests for DirectResolver internals will come in the next PR alongside the refactor.

## Test plan

- [x] Eval suite: 8 scenarios, 0 failures (~14s)
- [x] Full suite: 197 examples, 0 failures