### PR TITLE
Refactor DirectResolver to use Bundler::Definition

### DIFF
--- a/lib/direct_resolver.rb
+++ b/lib/direct_resolver.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler"
-require "bundler/resolver"
-require "bundler/resolver/base"
-require "bundler/source/rubygems"
+require "bundler/source/metadata"
 
 class DirectResolver
   Result = Struct.new(:compatible?, :error, :specs, keyword_init: true) do
@@ -29,39 +27,29 @@ class DirectResolver
     end
   end
 
-  class MetadataSource
+  # Subclass of Bundler's own Source::Metadata that provides specs at target
+  # runtime versions instead of the running process's versions.
+  class TargetMetadataSource < Bundler::Source::Metadata
     def initialize(runtime)
       @runtime = runtime
     end
 
     def specs
-      @specs ||= Bundler::Index.build do |index|
-        index << Gem::Specification.new("Ruby\0", @runtime.ruby_version_object.gem_version)
-        index << Gem::Specification.new("RubyGems\0", @runtime.rubygems_version) do |spec|
-          spec.required_rubygems_version = Gem::Requirement.default
+      @specs ||= Bundler::Index.build do |idx|
+        idx << Gem::Specification.new("Ruby\0", @runtime.ruby_version_object.gem_version)
+        idx << Gem::Specification.new("RubyGems\0", @runtime.rubygems_version) do |s|
+          s.required_rubygems_version = Gem::Requirement.default
         end
-        index << Gem::Specification.new do |spec|
-          spec.name = "bundler"
-          spec.version = Gem::Version.new(@runtime.bundler_version)
-          spec.platform = Gem::Platform::RUBY
-          spec.summary = "Synthetic Bundler spec for direct resolution"
-          spec.authors = ["compatibility"]
+        idx << Gem::Specification.new do |s|
+          s.name     = "bundler"
+          s.version  = Gem::Version.new(@runtime.bundler_version)
+          s.platform = Gem::Platform::RUBY
+          s.summary  = "Synthetic Bundler spec for direct resolution"
+          s.authors  = ["compatibility"]
         end
 
-        index.each { |spec| spec.source = self }
+        idx.each { |s| s.source = self }
       end
-    end
-
-    def options = {}
-    def to_s = "synthetic metadata source"
-
-    def ==(other)
-      other.class == self.class
-    end
-    alias eql? ==
-
-    def hash
-      self.class.hash
     end
   end
 
@@ -70,11 +58,6 @@ class DirectResolver
       super.reverse
     end
   end
-
-  PROMOTERS = {
-    latest: -> { Bundler::GemVersionPromoter.new },
-    earliest: -> { EarliestVersionPromoter.new }
-  }.freeze
 
   def initialize(
     rails_version:,
@@ -99,7 +82,9 @@ class DirectResolver
   def call
     Bundler.with_unbundled_env do
       Bundler.ui.silence do
-        specs = Bundler::Resolver.new(resolution_base, gem_version_promoter, nil).start
+        definition = build_definition
+        definition.resolve_remotely!
+        specs = definition.resolve
         versions = specs.each_with_object({}) { |s, h| h[s.name] = s.version.to_s }
         Result.new(compatible?: true, specs: versions)
       end
@@ -110,58 +95,36 @@ class DirectResolver
 
   private
 
-  def resolution_base
-    Bundler::Resolver::Base.new(
-      source_requirements,
-      expanded_dependencies,
-      Bundler::SpecSet.new([]),
-      [@runtime.local_platform],
-      locked_specs: Bundler::SpecSet.new([]),
-      unlock: true,
-      prerelease: gem_version_promoter.pre?,
-      prefer_local: false,
-      new_platforms: []
+  def build_definition
+    source_list = Bundler::SourceList.new
+    source_list.add_global_rubygems_remote("https://rubygems.org")
+    source_list.instance_variable_set(:@metadata_source, TargetMetadataSource.new(@runtime))
+
+    definition = Bundler::Definition.new(
+      Pathname.new("/dev/null/Gemfile.lock"),
+      user_dependencies,
+      source_list,
+      true,
+      @runtime.ruby_version_object
     )
-  end
 
-  def source_requirements
-    {
-      default: rubygems_source,
-      "Ruby\0" => metadata_source,
-      "RubyGems\0" => metadata_source,
-      "bundler" => metadata_source,
-    }
-  end
-
-  def expanded_dependencies
-    [
+    # Definition#metadata_dependencies hardcodes Bundler::RubyVersion.system
+    # and Gem::VERSION. Override to use target runtime versions.
+    definition.instance_variable_set(:@metadata_dependencies, [
       Bundler::Dependency.new("Ruby\0", @runtime.ruby_version_object.gem_version),
       Bundler::Dependency.new("RubyGems\0", @runtime.rubygems_version),
-      Bundler::Dependency.new("bundler", @runtime.bundler_version),
-      *user_dependencies,
-    ]
+    ])
+
+    if @promoter_key == :earliest
+      definition.instance_variable_set(:@gem_version_promoter, EarliestVersionPromoter.new)
+    end
+
+    definition
   end
 
   def user_dependencies
     @dependencies.map do |name, constraint|
       Bundler::Dependency.new(name, constraint.split(",").map(&:strip))
     end
-  end
-
-  def rubygems_source
-    @rubygems_source ||= begin
-      source = Bundler::Source::Rubygems.new("remotes" => ["https://rubygems.org"])
-      source.remote!
-      source.add_dependency_names(@dependencies.keys)
-      source
-    end
-  end
-
-  def metadata_source
-    @metadata_source ||= MetadataSource.new(@runtime)
-  end
-
-  def gem_version_promoter
-    @gem_version_promoter ||= PROMOTERS.fetch(@promoter_key).call
   end
 end

--- a/spec/lib/direct_resolver_spec.rb
+++ b/spec/lib/direct_resolver_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DirectResolver do
+  describe DirectResolver::Result do
+    it "exposes compatible?, error, and specs" do
+      result = described_class.new(compatible?: true, specs: { "foo" => "1.0" })
+
+      expect(result.compatible?).to be true
+      expect(result.error).to be_nil
+      expect(result.resolved_version("foo")).to eq("1.0")
+    end
+
+    it "exposes error for incompatible results" do
+      result = described_class.new(compatible?: false, error: "nope")
+
+      expect(result.compatible?).to be false
+      expect(result.error).to eq("nope")
+      expect(result.resolved_version("foo")).to be_nil
+    end
+  end
+
+  describe DirectResolver::TargetRuntime do
+    let(:runtime) do
+      described_class.new(
+        ruby_version: "3.4.2",
+        rubygems_version: "3.5.0",
+        bundler_version: "2.5.0",
+        platform: "ruby"
+      )
+    end
+
+    it "builds a RubyVersion object with the target version" do
+      expect(runtime.ruby_version_object).to be_a(Bundler::RubyVersion)
+      expect(runtime.ruby_version_object.gem_version).to eq(Gem::Version.new("3.4.2"))
+    end
+
+    it "returns Gem::Platform::RUBY for ruby platform" do
+      expect(runtime.local_platform).to eq(Gem::Platform::RUBY)
+    end
+
+    it "returns Gem::Platform::RUBY for nil platform" do
+      runtime = described_class.new(
+        ruby_version: "3.4.2",
+        rubygems_version: "3.5.0",
+        bundler_version: "2.5.0",
+        platform: nil
+      )
+
+      expect(runtime.local_platform).to eq(Gem::Platform::RUBY)
+    end
+  end
+
+  describe DirectResolver::TargetMetadataSource do
+    let(:runtime) do
+      DirectResolver::TargetRuntime.new(
+        ruby_version: "3.2.0",
+        rubygems_version: "3.4.0",
+        bundler_version: "2.4.0",
+        platform: "ruby"
+      )
+    end
+
+    let(:source) { described_class.new(runtime) }
+
+    it "is a Bundler::Source::Metadata subclass" do
+      expect(source).to be_a(Bundler::Source::Metadata)
+    end
+
+    it "provides specs for Ruby, RubyGems, and bundler at target versions" do
+      specs = source.specs
+
+      ruby_spec = specs.search("Ruby\0").first
+      expect(ruby_spec.version).to eq(Gem::Version.new("3.2.0"))
+
+      rubygems_spec = specs.search("RubyGems\0").first
+      expect(rubygems_spec.version).to eq(Gem::Version.new("3.4.0"))
+
+      bundler_spec = specs.search("bundler").first
+      expect(bundler_spec.version).to eq(Gem::Version.new("2.4.0"))
+    end
+
+    it "sets itself as the source on all specs" do
+      source.specs.each do |spec|
+        expect(spec.source).to eq(source)
+      end
+    end
+
+    it "inherits equality and options from Source::Metadata" do
+      other = described_class.new(runtime)
+      expect(source).to eq(other)
+      expect(source.hash).to eq(other.hash)
+      expect(source.options).to eq({})
+    end
+  end
+
+  describe DirectResolver::EarliestVersionPromoter do
+    it "is a GemVersionPromoter subclass that reverses sort_versions" do
+      promoter = described_class.new
+
+      expect(promoter).to be_a(Bundler::GemVersionPromoter)
+
+      dummy_result = [3, 1, 2]
+      allow_any_instance_of(Bundler::GemVersionPromoter).to receive(:sort_versions).and_return(dummy_result)
+
+      expect(promoter.sort_versions(nil, nil)).to eq([2, 1, 3])
+    end
+  end
+
+  describe "#call" do
+    let(:ruby_version) { "3.4.2" }
+    let(:rails_version) { "8.0" }
+
+    it "builds a Definition and resolves through it" do
+      resolver = DirectResolver.new(
+        rails_version: rails_version,
+        ruby_version: ruby_version,
+        dependencies: { "rack" => ">= 2.0" }
+      )
+
+      mock_spec_set = instance_double(Bundler::SpecSet)
+      allow(mock_spec_set).to receive(:each_with_object).and_return(
+        { "rack" => "3.1.0", "rails" => "8.0.1" }
+      )
+
+      mock_definition = instance_double(Bundler::Definition)
+      allow(mock_definition).to receive(:resolve_remotely!)
+      allow(mock_definition).to receive(:resolve).and_return(mock_spec_set)
+
+      allow(resolver).to receive(:build_definition).and_return(mock_definition)
+
+      result = resolver.call
+
+      expect(result.compatible?).to be true
+      expect(result.specs).to eq({ "rack" => "3.1.0", "rails" => "8.0.1" })
+    end
+
+    it "catches SolveFailure and returns incompatible Result" do
+      resolver = DirectResolver.new(
+        rails_version: rails_version,
+        ruby_version: ruby_version,
+        dependencies: { "rack" => ">= 2.0" }
+      )
+
+      mock_definition = instance_double(Bundler::Definition)
+      allow(mock_definition).to receive(:resolve_remotely!)
+        .and_raise(Bundler::SolveFailure.new("no solution"))
+
+      allow(resolver).to receive(:build_definition).and_return(mock_definition)
+
+      result = resolver.call
+
+      expect(result.compatible?).to be false
+      expect(result.error).to eq("no solution")
+    end
+
+    it "catches GemNotFound and returns incompatible Result" do
+      resolver = DirectResolver.new(
+        rails_version: rails_version,
+        ruby_version: ruby_version,
+        dependencies: { "rack" => ">= 2.0" }
+      )
+
+      mock_definition = instance_double(Bundler::Definition)
+      allow(mock_definition).to receive(:resolve_remotely!)
+        .and_raise(Bundler::GemNotFound, "gem not found")
+
+      allow(resolver).to receive(:build_definition).and_return(mock_definition)
+
+      result = resolver.call
+
+      expect(result.compatible?).to be false
+      expect(result.error).to eq("gem not found")
+    end
+  end
+
+  describe "#build_definition" do
+    it "creates a Definition with SourceList, target metadata, and user deps" do
+      resolver = DirectResolver.new(
+        rails_version: "8.0",
+        ruby_version: "3.4.2",
+        dependencies: { "rack" => ">= 2.0" }
+      )
+
+      definition = resolver.send(:build_definition)
+
+      expect(definition).to be_a(Bundler::Definition)
+
+      # Metadata source is our TargetMetadataSource
+      source_list = definition.instance_variable_get(:@sources)
+      expect(source_list.metadata_source).to be_a(DirectResolver::TargetMetadataSource)
+
+      # Metadata dependencies use target versions, not system versions
+      metadata_deps = definition.instance_variable_get(:@metadata_dependencies)
+      ruby_dep = metadata_deps.find { |d| d.name == "Ruby\0" }
+      expect(ruby_dep.requirement).to eq(Gem::Requirement.new("= 3.4.2"))
+    end
+
+    it "injects EarliestVersionPromoter when promoter is :earliest" do
+      resolver = DirectResolver.new(
+        rails_version: "8.0",
+        ruby_version: "3.4.2",
+        promoter: :earliest
+      )
+
+      definition = resolver.send(:build_definition)
+      promoter = definition.instance_variable_get(:@gem_version_promoter)
+
+      expect(promoter).to be_a(DirectResolver::EarliestVersionPromoter)
+    end
+
+    it "uses default GemVersionPromoter when promoter is :latest" do
+      resolver = DirectResolver.new(
+        rails_version: "8.0",
+        ruby_version: "3.4.2",
+        promoter: :latest
+      )
+
+      definition = resolver.send(:build_definition)
+      promoter = definition.instance_variable_get(:@gem_version_promoter)
+
+      expect(promoter).to be_nil
+    end
+  end
+
+  describe "rails dependency" do
+    it "merges rails constraint from rails_version" do
+      resolver = DirectResolver.new(
+        rails_version: "7.2",
+        ruby_version: "3.3.0",
+        dependencies: { "devise" => ">= 4.0" }
+      )
+
+      deps = resolver.send(:user_dependencies)
+      rails_dep = deps.find { |d| d.name == "rails" }
+
+      expect(rails_dep.requirement.to_s).to eq("~> 7.2.0")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replace direct usage of `Bundler::Resolver`, `Resolver::Base`, `SpecSet`, and manual source wiring with `Bundler::Definition`
- `MetadataSource` duck-type replaced with `TargetMetadataSource < Bundler::Source::Metadata` (inherits full source protocol, no more missing methods risk)
- Manual `Source::Rubygems` setup replaced with `SourceList`
- 3 targeted ivar overrides on `Definition` inject target runtime versions where Bundler hardcodes system values

### Before vs after

| Aspect | Before | After |
|---|---|---|
| Bundler classes used directly | `Resolver`, `Resolver::Base`, `SpecSet`, `Source::Rubygems`, `Index`, `GemVersionPromoter` + duck-typed `MetadataSource` | `Definition`, `SourceList`, `Source::Metadata` subclass |
| Source protocol | Duck-typed (missing `install`, `version_message`, `checksum_store`, etc.) | Inherited from `Source::Metadata` |
| Breakage surface | Constructor signatures for `Resolver::Base` (9 args), `Resolver` (3 args) | `Definition.new` (stable) + 3 memoization ivar overrides |
| Lines (resolver setup) | ~90 | ~30 |

## Test plan

- [x] Unit tests: 17 examples, 0 failures
- [x] Eval suite: 8 scenarios, 0 failures
- [x] Full suite: 198 examples, 0 failures
- [x] `bin/resolve_gem` works end-to-end