### PR TITLE
Show resolved runtime on lockfile show page

### DIFF
--- a/app/services/checks/create.rb
+++ b/app/services/checks/create.rb
@@ -48,6 +48,8 @@ module Checks
 
       @lockfile.lockfile_checks.find_or_create_by!(rails_release: target_release) do |check|
         check.status = "pending"
+        check.current_rails_version = parser.rails_version
+        check.platforms = parser.platforms
         check.ruby_version = runtime.ruby_version
         check.rubygems_version = runtime.rubygems_version
         check.bundler_version = runtime.bundler_version

--- a/app/services/checks/lockfile_parser.rb
+++ b/app/services/checks/lockfile_parser.rb
@@ -31,5 +31,9 @@ module Checks
     def bundler_version
       @parser.bundler_version.presence
     end
+
+    def platforms
+      @parser.platforms.map(&:to_s)
+    end
   end
 end

--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -17,6 +17,35 @@
       <%= render "lockfile_checks/status_badge", lockfile_check: lockfile_check %>
     </div>
 
+    <div class="table-responsive mb-3">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Current Rails</th>
+            <th>Target Rails</th>
+            <th>Ruby</th>
+            <th>Bundler</th>
+            <th>RubyGems</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= lockfile_check.current_rails_version || "—" %></td>
+            <td><%= lockfile_check.rails_release.version %></td>
+            <td><%= lockfile_check.ruby_version %></td>
+            <td><%= lockfile_check.bundler_version %></td>
+            <td><%= lockfile_check.rubygems_version %></td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="text-muted small mb-0">
+        Ruby and Bundler come from the <code>Gemfile.lock</code> you provided,
+        unless the target Rails version requires a newer minimum, in which
+        case we use that minimum instead. RubyGems is derived from the chosen
+        Ruby version.
+      </p>
+    </div>
+
     <% if lockfile_check.gem_checks.any? %>
       <div class="table-responsive">
         <table class="table table-striped">

--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -30,7 +30,7 @@
         </thead>
         <tbody>
           <tr>
-            <td><%= lockfile_check.current_rails_version || "—" %></td>
+            <td><%= lockfile_check.current_rails_version %></td>
             <td><%= lockfile_check.rails_release.version %></td>
             <td><%= lockfile_check.ruby_version %></td>
             <td><%= lockfile_check.bundler_version %></td>

--- a/db/migrate/20260421204234_add_current_rails_version_and_platforms_to_lockfile_checks.rb
+++ b/db/migrate/20260421204234_add_current_rails_version_and_platforms_to_lockfile_checks.rb
@@ -1,0 +1,6 @@
+class AddCurrentRailsVersionAndPlatformsToLockfileChecks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :lockfile_checks, :current_rails_version, :string
+    add_column :lockfile_checks, :platforms, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_07_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_21_204234) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -87,6 +87,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_07_000001) do
     t.string "bundler_version"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "current_rails_version"
+    t.string "platforms", default: [], null: false, array: true
     t.index ["lockfile_id", "rails_release_id"], name: "index_lockfile_checks_on_lockfile_id_and_rails_release_id", unique: true
     t.index ["lockfile_id"], name: "index_lockfile_checks_on_lockfile_id"
     t.index ["rails_release_id"], name: "index_lockfile_checks_on_rails_release_id"

--- a/spec/services/checks/create_spec.rb
+++ b/spec/services/checks/create_spec.rb
@@ -94,6 +94,15 @@ RSpec.describe Checks::Create, type: :service, new_check_flow: true do
         expect(lockfile_check.status).to eq("pending")
       end
 
+      it "stores the lockfile's current Rails version and platforms" do
+        lockfile = build_lockfile(lockfile_content(rails_version: "7.1.3"))
+
+        lockfile_check = described_class.new(lockfile).call
+
+        expect(lockfile_check.current_rails_version).to eq("7.1")
+        expect(lockfile_check.platforms).to eq(["ruby"])
+      end
+
       it "is idempotent across calls" do
         lockfile = build_lockfile(lockfile_content(rails_version: "7.1.3"))
 

--- a/spec/services/checks/lockfile_parser_spec.rb
+++ b/spec/services/checks/lockfile_parser_spec.rb
@@ -84,4 +84,12 @@ RSpec.describe Checks::LockfileParser, type: :service, new_check_flow: true do
       expect(parser.dependencies.keys).to include("rails")
     end
   end
+
+  describe "#platforms" do
+    it "returns the lockfile platforms as strings" do
+      parser = described_class.new(lockfile_content)
+
+      expect(parser.platforms).to eq(["ruby"])
+    end
+  end
 end


### PR DESCRIPTION


## Why

On the new-flow lockfile show page users see per-gem compatibility
results but no visibility into *which runtime environment* produced
them. When a result looks off, the first question is "what did we
actually resolve against?". This PR surfaces that.

## What changed

### Schema

- New migration adds two columns to `lockfile_checks`:
  - `current_rails_version:string` — the Rails version parsed from
    the user's Gemfile.lock (`major.minor`).
  - `platforms:string[]` — the lockfile platforms, defaulting to
    `[]`, `null: false`. Stored now so we can support non-Ruby
    platforms later without another migration.

### Parser / service

- `Checks::LockfileParser#platforms` exposes the lockfile platforms.
- `Checks::Create` writes `current_rails_version` and `platforms`
  onto the `lockfile_check` at creation time, so the show page
  doesn't have to re-parse the Gemfile.lock on every request.

### View

- `show_new.html.erb` renders a runtime table above the existing
  gem_checks table, with one row per `lockfile_check`:

  | Current Rails | Target Rails | Ruby | Bundler | RubyGems |

  A short caption explains the resolution rule:

  > Ruby and Bundler come from the Gemfile.lock you provided,
  > unless the target Rails version requires a newer minimum, in
  > which case we use that minimum instead. RubyGems is derived
  > from the chosen Ruby version.

- `platforms` is persisted but not rendered yet; we only support
  `ruby` today, so the column would always read the same. The
  data is ready when we start checking other platforms.

## Test plan

- [ ] `bundle exec rspec`
- [ ] Submit a Gemfile.lock locally with `ENABLE_NEW_CHECK_FLOW=1`,
  visit the show page, confirm the runtime table matches the
  lockfile's Ruby/Bundler values (or the Rails minimum when
  higher).
- [ ] Smoke test in staging end-to-end.
