### PR TITLE
Serialize DirectResolver subprocess spawns to prevent R14 on 512MB worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "amazing_print",                            "~> 1.5"
 gem "aws-sdk-s3",                               "~> 1.8",  require: false
 gem "baseline",                                 github: "fastruby/baseline"
 gem "bootsnap",                                 "~> 1.17", require: false
-gem "coverband",                                "~> 6.1"
+gem "coverband",                                "~> 6.1", require: false
 gem "bootstrap",                                "~> 5.3.3"
 gem "cgi"
 gem "dartsass-rails",                           "~> 0.5"

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails assets:precompile && bundle exec puma -C config/puma.rb
-worker: jemalloc.sh bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
+worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
 release: bin/rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails assets:precompile && bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
+worker: jemalloc.sh bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
 release: bin/rails db:migrate

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,4 +1,6 @@
 if ENV["COVERBAND_PASSWORD"].present?
+  require "coverband"
+
   Coverband.configure do |config|
     config.store = Coverband::Adapters::RedisStore.new(
       Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })

--- a/lib/direct_resolver/subprocess.rb
+++ b/lib/direct_resolver/subprocess.rb
@@ -6,6 +6,7 @@ require "json"
 class DirectResolver
   class Subprocess
     SCRIPT = File.expand_path("../../../bin/resolve_gem", __FILE__)
+    MUTEX = Mutex.new
 
     def initialize(rails_version:, ruby_version:, dependencies: {}, rubygems_version: Gem::VERSION, bundler_version: Bundler::VERSION, promoter: :latest)
       @config = {
@@ -19,11 +20,13 @@ class DirectResolver
     end
 
     def call
-      stdout, stderr, status = Open3.capture3(
-        { "BUNDLE_GEMFILE" => "" },
-        RbConfig.ruby, SCRIPT,
-        stdin_data: JSON.generate(@config)
-      )
+      stdout, stderr, status = MUTEX.synchronize do
+        Open3.capture3(
+          { "BUNDLE_GEMFILE" => "" },
+          RbConfig.ruby, SCRIPT,
+          stdin_data: JSON.generate(@config)
+        )
+      end
 
       unless status.success?
         return DirectResolver::Result.new(


### PR DESCRIPTION
Closes #192

## Summary

Serialize `DirectResolver::Subprocess#call` with a class-level `Mutex` so only one resolver subprocess runs at a time per worker dyno. Also stop `coverband` from auto-starting when `COVERBAND_PASSWORD` is unset, and document the memory behavior in the README.

## Why

`Checks::ResolveGem` (Sidekiq job) shells out to `bin/resolve_gem` via `Open3.capture3`. Each child boots Ruby, loads Bundler, and pulls the rubygems.org compact index, peaking around 150-300MB RSS per subprocess.

On `railsbump-staging` (Basic dyno, 512MB, `SIDEKIQ_CONCURRENCY=3`), submitting a lockfile spawned three concurrent subprocesses and blew the memory quota:

```
heroku[worker.1]: Process running mem=716M(139.9%)
heroku[worker.1]: Error R14 (Memory quota exceeded)
```

## What changed

- `lib/direct_resolver/subprocess.rb`: `MUTEX = Mutex.new` at class level; `MUTEX.synchronize { Open3.capture3(...) }`. Only the subprocess spawn is serialized; Sidekiq threads still run DB writes and Turbo broadcasts in parallel before/after the lock.
- `Gemfile` + `config/coverband.rb`: `coverband` is now loaded with `require: false` and only required when `COVERBAND_PASSWORD` is set. Without this, Coverband's Railtie auto-started a background reporter against `REDIS_URL` with strict TLS verification, causing a flood of `Redis::CannotConnectError` (self-signed cert) errors on staging. This is a separate bug that surfaced while debugging the memory issue.
- `README.md`: added a "Worker memory considerations" section explaining the Mutex and the 512MB dyno sweet spot.

## Verification on staging

All runs are the same lockfile, submitted through the new flow on `railsbump-staging` (Basic, 512MB).

| Setup | Peak RSS | R14 | Avg job wall time |
|-------|---------:|:---:|------------------:|
| No Mutex, `SIDEKIQ_CONCURRENCY=3` | 716MB (139.9%) | yes | ~7s (unreliable) |
| No Mutex, `SIDEKIQ_CONCURRENCY=1` | under quota | no  | ~2s |
| Mutex, `SIDEKIQ_CONCURRENCY=3`    | under quota | no  | ~7s |
| Mutex, `SIDEKIQ_CONCURRENCY=6`    | under quota | no  | ~12s |
| Mutex, `SIDEKIQ_CONCURRENCY=10`   | under quota | no  | ~19s |

Past ~3 the Mutex becomes the bottleneck (subprocess is serial), so extra concurrency only grows per-job wall-time without improving throughput. `SIDEKIQ_CONCURRENCY=3` is the recommended value for a 512MB worker.

## Allocator tuning side experiments (did not replace the Mutex)

Tested on the same lockfile, without the Mutex, to see if cheap allocator tweaks alone could keep us under 512MB at `SIDEKIQ_CONCURRENCY=3`:

| Setup | Peak RSS | R14 |
|-------|---------:|:---:|
| No tuning                       | 716MB       | yes |
| `MALLOC_ARENA_MAX=2`            | 545-679MB   | yes |
| `MALLOC_ARENA_MAX=2` + jemalloc | 656-740MB   | yes |

`MALLOC_ARENA_MAX=2` gave a real ~25% RSS cut and was kept on staging (no code change, safe default for Ruby on Heroku/glibc). The jemalloc buildpack made things slightly worse in this workload (short-lived Open3 children that don't give jemalloc's arenas time to settle), and it implicitly disables `MALLOC_ARENA_MAX` by replacing glibc's allocator. Buildpack was rolled back.

## Notes on scope

- The new lockfile flow (`FeatureFlags.new_check_flow?`) is still off in production, so the R14 was a staging-only symptom. This PR stabilizes staging so we can keep iterating on the new flow, and protects production when the flag is enabled.
- If we later move the worker to a larger dyno (Standard-2X), the Mutex keeps peak RAM flat but does not use the extra headroom; we would want to swap it for `Concurrent::Semaphore.new(N)` to allow N parallel subprocesses, sized to dyno RAM.
- A follow-up improvement worth considering: one long-lived resolver subprocess per worker dyno, driven by JSON over stdin. That would amortize Bundler boot and drop per-job work from seconds to milliseconds, and would make the Mutex unnecessary.

## Test plan

- [x] Deploy to staging, confirm no R14 at `SIDEKIQ_CONCURRENCY=3`.
- [x] Confirm no Coverband Redis errors after restart.
- [x] Bump staging concurrency to 6 and 10; confirm still no R14, throughput flat.
- [ ] After merge: leave production `SIDEKIQ_CONCURRENCY=2`. When the new check flow is enabled in production, bump to 3.
