### PR TITLE
Probe memory leak: exclude status_determined_by from CheckUnchecked batches

### DIFF
--- a/app/services/compats/check_unchecked.rb
+++ b/app/services/compats/check_unchecked.rb
@@ -19,6 +19,7 @@ module Compats
           rails_release
             .compats
             .unchecked
+            .select(Compat.column_names - ["status_determined_by"])
             .find_each do |compat|
 
             return unless count < LIMIT


### PR DESCRIPTION
## Summary

Probe for a suspected memory leak on the Sidekiq worker dyno. Excludes the `status_determined_by` column from the `Compats::CheckUnchecked` batch `SELECT` so each scheduler tick stops pulling hundreds of MB of bundler output + backtraces into a long-lived process.

## Background

Heroku metrics show worker RSS climbing monotonically between restarts. `Compats::CheckUnchecked` runs every 10 minutes via Heroku Scheduler and iterates unchecked compats with `find_each` (default batch = 1000).

`status_determined_by` stores the full `bundle install` stdout plus the Ruby backtrace captured by `railsbump/checker`. For `BundleLocallyCheck` failures (notably `sorbet-static` resolution errors) individual rows reach **500+ KB**, and the column totals **~505 MB** across the `compats` table:

```
 avg_len | max_len | total_len
---------+---------+-----------
 465 B   | 560 kB  | 505 MB
```

Each tick AR-instantiates a batch that can hold tens to hundreds of MB. In a long-lived Sidekiq process the heap fragments and RSS never fully releases.

## Change

```ruby
rails_release
  .compats
  .unchecked
  .select(Compat.column_names - ["status_determined_by"])
  .find_each do |compat|
```

## Why it is safe

Grepped all check strategies: `status_determined_by` is only assigned, never read.

- `Compats::Checks::EmptyDependenciesCheck`
- `Compats::Checks::RailsGemsCheck`
- `Compats::Checks::DependencySubsetsCheck`
- `Compats::Checks::BundlerGithubCheck`

`Compat#process_result` also only writes this column. ActiveRecord dirty tracking still persists writes on save even when the column was not selected.

## How to verify

1. Deploy to production.
2. Watch the worker dyno memory graph for 2-3 scheduler ticks (~30 min).
3. If the RSS slope flattens, the hypothesis is confirmed.
4. Rollback is a one-line revert.

## Follow-ups (separate PRs)

- Truncate `output` at write in `Compat#process_result` (e.g. 8 KB head + 2 KB tail) to stop the bleed for new rows.
- Switch `CheckUnchecked` to `select(:id)` + per-iteration refetch for a cleaner final form.
- Backfill migration to trim existing bloated `status_determined_by` values (> 16 KB) in batches.
- Structural: move output to a separate `compat_results` table loaded only on the detail view.

## Test plan

- [ ] Deploy to production
- [ ] Observe worker dyno memory graph flattens across at least 3 scheduler ticks
- [ ] Confirm new compat results are still persisted with the correct `status_determined_by` value
- [ ] Confirm no regression in `Compats::Check` strategies (logs show normal compatible/incompatible resolutions)
