### PR TITLE
Fix: Memory Leak Web

### DIFF
--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -25,6 +25,11 @@ module API
 
     def sanitize_result_params!
       if params[:result].is_a?(ActionController::Parameters)
+        # PROBE: capture :output size, then drop it entirely to test the
+        # web-dyno memory leak hypothesis. Revert once confirmed.
+        @output_size = params[:result][:output].to_s.bytesize
+        logger.info "PARAMS_OUTPUT_BYTESIZE #{@output_size}"
+        params[:result].delete(:output)
         params[:result].each_key do |key|
           value = params[:result][key]
           params[:result][key] = value.delete("\x00") if value.is_a?(String)

--- a/app/models/compat.rb
+++ b/app/models/compat.rb
@@ -81,14 +81,14 @@ class Compat < ApplicationRecord
       self.update(
         checked_at: Time.current,
         status: :compatible,
-        status_determined_by: "#{result[:strategy]}\nOutput: #{result[:output]}"
+        status_determined_by: "#{result[:strategy]}"
       )
     else
       logger.info "Compat #{id} result is not compatible"
       self.update(
         checked_at: Time.current,
         status: :incompatible,
-        status_determined_by: "#{result[:strategy]}\nOutput: #{result[:output]}"
+        status_determined_by: "#{result[:strategy]}"
       )
     end
   end


### PR DESCRIPTION
## Summary

Stop carrying the full `bundle install` output (from the `checker` repo) around on the web dyno. It was being logged, stored, and held in memory long after it had any useful purpose, and it was the main driver of RSS pressure on `web.1`.

## Background

RailsBump determines gem compatibility with a layered strategy. When the cheaper strategies cannot decide, the app dispatches a GitHub Actions workflow in `railsbump/checker`. That workflow runs `bundle install` against a generated `Gemfile` and reports the result back to the app via `POST /api/results` with a JSON payload that includes:

- `compat_id`
- `rails_version`
- `dependencies`
- `result`, which itself contains `strategy`, `status`, and `output` (the full stdout of `bundle install`, plus a backtrace on failure)

For some gems, `output` is tens to hundreds of kilobytes. For failures that touch `sorbet-static`, individual `output` strings exceed **500 KB** per request.

On prod we were seeing:

- web dyno average memory **918 MB** (of a 1,024 MB quota)
- web dyno max **1,134 MB** (110% of quota, R14-adjacent)

Local reproduction with `derailed_benchmarks` against GET endpoints and against `POST /api/results` with a 2 MB payload did **not** reproduce the leak, which is what pointed us at the slow accumulation path rather than a single-request blow-up.

## Change

Two small changes in the same path:

1. In `API::ResultsController#sanitize_result_params!`, drop `params[:result][:output]` as early as possible, before any further processing, logging, or param filtering:

    ```ruby
    params[:result].delete(:output)
    ```

    This keeps the huge string out of Rails' parameter logging, Sentry breadcrumbs, and any subsequent serialization.

2. In `Compat#process_result`, stop concatenating `output` into the `status_determined_by` text column. The column now stores only the strategy name:

    ```ruby
    status_determined_by: "#{result[:strategy]}"
    ```

    Previously every processed compat persisted the full bundler output, which also fed back into the worker-side problem addressed by #199 (the `CheckUnchecked` scheduler loading batches of this column).

## Impact

Post-deploy metrics (web dyno, Standard-2X):

| Metric   | Before  | After   |
|----------|---------|---------|
| Avg RSS  | 918 MB  | ~606 MB |
| Max RSS  | 1134 MB | ~647 MB |
| % quota  | 110%    | ~63%    |

No R14 since the deploy. The app can probably go back to Standard-1X on the web dyno.

## Related

- #199 addresses the same data on the worker side by excluding `status_determined_by` from the `Compats::CheckUnchecked` batch `SELECT`.

## Test plan

- [x] Prod `POST /api/results` still processes results correctly (status transitions observed on recent compats).
- [x] `status_determined_by` now contains just the strategy name for newly processed compats.
- [x] Heroku memory graph shows sustained drop, no R14 events.
