### PR TITLE
Wrap puma and sidekiq with jemalloc.sh

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bin/rails assets:precompile && bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
+web: bin/rails assets:precompile && jemalloc.sh bundle exec puma -C config/puma.rb
+worker: jemalloc.sh bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-2}
 release: bin/rails db:migrate


### PR DESCRIPTION
## Summary

Wrap the `web` and `worker` Procfile entries with `jemalloc.sh` so both Puma and Sidekiq run under jemalloc instead of glibc's default allocator.

## New hypothesis for the remaining web dyno leak

After #199 (exclude `status_determined_by` from `CheckUnchecked` batches) and railsbump/checker#40 (stop sending `:output` in the POST `/results` payload) were merged and deployed, the web.1 RSS on `railsbump-production` is **still** climbing.

Concrete data from 2026-04-24:

- Restart at ~16:30 UTC. Baseline sample at 16:48 UTC: web.1 RSS = 537 MB.
- Sample at 19:50 UTC (t+3h): web.1 RSS = 714 MB. Net +177 MB.
- 33-min window 19:26–19:59 UTC, 95 samples: RSS climbed 706.5 → 726.1 MB monotonically (+35.8 MB/h, no dips). During that window the last checker workflow run was 17:32 UTC, so there were **zero** POST `/results` hits.
- Stress test: dispatched 10 workflow runs, 8 POSTs clustered at 20:26:09–20:26:32 UTC. RSS before burst 756.31 MB, after burst 756.64 MB, total +0.33 MB for 8 POSTs. Indistinguishable from baseline drift.
- The `Parameters:` log line for those POSTs shows no `:output` key in the `result` hash at all, confirming railsbump/checker#40 is doing its job on the web side.

So the remaining climb is **not** `:output` logging allocation and **not** traffic-proportional to `POST /results`. Schedulers run on separate one-off dynos (we see `scheduler.3933`, `scheduler.7822`, etc. in the logs) so they cannot contribute to web.1 RSS. Sidekiq runs on worker.1, also separate. The climb is in the Puma process itself.

Monotonic RSS growth with no GC-visible reclaim in a long-lived multi-threaded Ruby process is the textbook symptom of glibc `malloc` arena fragmentation, not a reference leak. jemalloc uses per-thread arenas with better fragmentation behavior and, importantly, `mmap`s large regions and `madvise(DONTNEED)`s them back to the OS so RSS actually comes down. On Heroku this commonly flattens exactly the curve shape we're seeing.

## Deploy steps (not in the diff)

The buildpack needs to be added before this branch is deployed:

```bash
heroku buildpacks:add --index 1 https://github.com/gaffneyc/heroku-buildpack-jemalloc.git -a railsbump-production
heroku config:set JEMALLOC_ENABLED=true -a railsbump-production
# merge + deploy this PR, or `heroku ps:restart` after the deploy auto-triggers on merge
```

Without the buildpack, `jemalloc.sh` won't exist on PATH and the web/worker processes will fail to boot. Do NOT merge until the buildpack is added.

## Test plan

- [ ] Buildpack added on `railsbump-production`.
- [ ] Deploy this branch and verify `heroku ps` shows both web.1 and worker.1 up.
- [ ] Confirm jemalloc is active: `heroku logs -a railsbump-production -n 50 | grep -i jemalloc` should show a startup line from `jemalloc.sh`.
- [ ] Sample web.1 RSS with `bin/sample_memory.sh` at t+0, t+1h, t+3h and confirm slope is near flat instead of +35 MB/h.
- [ ] If slope does not flatten, revert and investigate alternative causes (bot traffic on gem compat pages, Faraday/Octokit connection leaks, kredis client buffers).

## Related

- #199 — Exclude `status_determined_by` from `CheckUnchecked` batches
- #200 — Drop `:output` from results controller params (app side)
- railsbump/checker#40 — Stop sending `:output` in result payload (checker side)
