### PR TITLE
Pre-flight Gemfile.lock submissions with Lockfile::Inspection

### DIFF
--- a/app/controllers/api/lockfiles_controller.rb
+++ b/app/controllers/api/lockfiles_controller.rb
@@ -12,9 +12,13 @@ module API
       case result.reason
       when :runnable
         lockfile = result.lockfile
-        lockfile.save!
-        lockfile.run_check!
-        render_pending(lockfile)
+
+        if lockfile.save
+          lockfile.run_check!
+          render_pending(lockfile)
+        else
+          render json: { reason: :invalid_content, errors: lockfile.errors.full_messages }, status: :unprocessable_content
+        end
       else
         render json: { reason: result.reason, errors: [result.message] }, status: result.http_status
       end

--- a/app/controllers/api/lockfiles_controller.rb
+++ b/app/controllers/api/lockfiles_controller.rb
@@ -12,13 +12,9 @@ module API
       case result.reason
       when :runnable
         lockfile = result.lockfile
-
-        if lockfile.save
-          lockfile.run_check!
-          render_pending(lockfile)
-        else
-          render json: { reason: :invalid_content, errors: lockfile.errors.full_messages }, status: :unprocessable_content
-        end
+        lockfile.save!
+        lockfile.run_check!
+        render_pending(lockfile)
       else
         render json: { reason: result.reason, errors: [result.message] }, status: result.http_status
       end

--- a/app/controllers/api/lockfiles_controller.rb
+++ b/app/controllers/api/lockfiles_controller.rb
@@ -7,13 +7,16 @@ module API
     before_action :set_lockfile, only: :show
 
     def create
-      lockfile = Lockfile.new(content: lockfile_content)
+      result = Lockfile::Inspection.call(lockfile_content)
 
-      if lockfile.save
+      case result.reason
+      when :runnable
+        lockfile = result.lockfile
+        lockfile.save!
         lockfile.run_check!
         render_pending(lockfile)
       else
-        render json: { errors: lockfile.errors.full_messages }, status: :unprocessable_content
+        render json: { errors: [result.message] }, status: result.http_status
       end
     end
 

--- a/app/controllers/api/lockfiles_controller.rb
+++ b/app/controllers/api/lockfiles_controller.rb
@@ -16,7 +16,7 @@ module API
         lockfile.run_check!
         render_pending(lockfile)
       else
-        render json: { errors: [result.message] }, status: result.http_status
+        render json: { reason: result.reason, errors: [result.message] }, status: result.http_status
       end
     end
 

--- a/app/controllers/lockfiles_controller.rb
+++ b/app/controllers/lockfiles_controller.rb
@@ -28,9 +28,13 @@ class LockfilesController < ApplicationController
       case result.reason
       when :runnable
         @lockfile = result.lockfile
-        @lockfile.save!
-        @lockfile.run_check!
-        redirect_to @lockfile, status: :see_other
+
+        if @lockfile.save
+          @lockfile.run_check!
+          redirect_to @lockfile, status: :see_other
+        else
+          redirect_to new_lockfile_path, flash: { alert: @lockfile.errors.full_messages.join(". ") }
+        end
       else
         redirect_to new_lockfile_path, flash: { alert: result.message }
       end

--- a/app/controllers/lockfiles_controller.rb
+++ b/app/controllers/lockfiles_controller.rb
@@ -28,13 +28,9 @@ class LockfilesController < ApplicationController
       case result.reason
       when :runnable
         @lockfile = result.lockfile
-
-        if @lockfile.save
-          @lockfile.run_check!
-          redirect_to @lockfile, status: :see_other
-        else
-          redirect_to new_lockfile_path, flash: { alert: @lockfile.errors.full_messages.join(". ") }
-        end
+        @lockfile.save!
+        @lockfile.run_check!
+        redirect_to @lockfile, status: :see_other
       else
         redirect_to new_lockfile_path, flash: { alert: result.message }
       end

--- a/app/controllers/lockfiles_controller.rb
+++ b/app/controllers/lockfiles_controller.rb
@@ -23,13 +23,16 @@ class LockfilesController < ApplicationController
   private
 
     def create_new_flow
-      @lockfile = Lockfile.new(content: lockfile_params.fetch(:content).strip)
+      result = Lockfile::Inspection.call(lockfile_params.fetch(:content))
 
-      if @lockfile.save
+      case result.reason
+      when :runnable
+        @lockfile = result.lockfile
+        @lockfile.save!
         @lockfile.run_check!
         redirect_to @lockfile, status: :see_other
       else
-        redirect_to new_lockfile_path, flash: { alert: @lockfile.errors.full_messages.join(". ") }
+        redirect_to new_lockfile_path, flash: { alert: result.message }
       end
     end
 

--- a/app/models/lockfile.rb
+++ b/app/models/lockfile.rb
@@ -24,6 +24,10 @@ class Lockfile < ApplicationRecord
     DEPENDENCIES
   )xm.freeze
 
+  def self.valid_content?(content)
+    CONTENT_REGEX.match?(content.to_s)
+  end
+
   def parsed
     @parsed ||= Parsed.new(content)
   end
@@ -86,7 +90,7 @@ class Lockfile < ApplicationRecord
   end
 
   def validate_content
-    unless CONTENT_REGEX.match?(content)
+    unless self.class.valid_content?(content)
       self.errors.add(:content, "does not look like a valid lockfile.")
     end
   end

--- a/app/models/lockfile/inspection.rb
+++ b/app/models/lockfile/inspection.rb
@@ -38,7 +38,7 @@ class Lockfile
     end
 
     def call
-      return result(:invalid_content) unless valid_content?
+      return result(:invalid_content) unless Lockfile.valid_content?(@content)
 
       lockfile = Lockfile.new(content: @content)
 
@@ -55,10 +55,6 @@ class Lockfile
 
       def result(reason, lockfile: nil)
         Result.new(reason: reason, lockfile: lockfile)
-      end
-
-      def valid_content?
-        Lockfile::CONTENT_REGEX.match?(@content)
       end
   end
 end

--- a/app/models/lockfile/inspection.rb
+++ b/app/models/lockfile/inspection.rb
@@ -44,6 +44,7 @@ class Lockfile
 
       return result(:no_rails_dependency) if lockfile.rails_version.blank?
       return result(:up_to_date)          if lockfile.next_rails_release.nil?
+      return result(:invalid_content)     if lockfile.invalid?
 
       result(:runnable, lockfile: lockfile)
     rescue Bundler::LockfileError

--- a/app/models/lockfile/inspection.rb
+++ b/app/models/lockfile/inspection.rb
@@ -46,6 +46,8 @@ class Lockfile
       return result(:up_to_date)          if lockfile.next_rails_release.nil?
 
       result(:runnable, lockfile: lockfile)
+    rescue Bundler::LockfileError
+      result(:invalid_content)
     end
 
     private

--- a/app/models/lockfile/inspection.rb
+++ b/app/models/lockfile/inspection.rb
@@ -1,0 +1,61 @@
+class Lockfile
+  # Pre-flight check on a submitted Gemfile.lock string. Returns a Result with
+  # a reason code that callers (controllers, jobs) can branch on without
+  # persisting anything. Centralized REASONS table makes adding new
+  # rejection cases a one-line change.
+  class Inspection
+    Result = Data.define(:reason, :lockfile) do
+      def message     = REASONS.fetch(reason).fetch(:message)
+      def http_status = REASONS.fetch(reason).fetch(:http_status)
+      def runnable?   = reason == :runnable
+    end
+
+    REASONS = {
+      runnable: {
+        http_status: :accepted,
+        message: nil
+      },
+      up_to_date: {
+        http_status: :ok,
+        message: "Your Gemfile.lock is already on the latest known Rails version. There is no upgrade target to check against."
+      },
+      no_rails_dependency: {
+        http_status: :unprocessable_content,
+        message: "This Gemfile.lock has no Rails dependency. RailsBump only checks Rails apps."
+      },
+      invalid_content: {
+        http_status: :unprocessable_content,
+        message: "Content does not look like a valid Gemfile.lock."
+      }
+    }.freeze
+
+    def self.call(content)
+      new(content).call
+    end
+
+    def initialize(content)
+      @content = content.to_s.strip
+    end
+
+    def call
+      return result(:invalid_content) unless valid_content?
+
+      lockfile = Lockfile.new(content: @content)
+
+      return result(:no_rails_dependency) if lockfile.rails_version.blank?
+      return result(:up_to_date)          if lockfile.next_rails_release.nil?
+
+      result(:runnable, lockfile: lockfile)
+    end
+
+    private
+
+      def result(reason, lockfile: nil)
+        Result.new(reason: reason, lockfile: lockfile)
+      end
+
+      def valid_content?
+        Lockfile::CONTENT_REGEX.match?(@content)
+      end
+  end
+end

--- a/app/serializers/api/pending_lockfile_serializer.rb
+++ b/app/serializers/api/pending_lockfile_serializer.rb
@@ -9,6 +9,7 @@ module API
     def as_json(*)
       {
         slug: @lockfile.slug,
+        reason: "runnable",
         status: "pending",
         status_url: @status_url,
         retry_after_seconds: @retry_after_seconds,
@@ -19,7 +20,7 @@ module API
     private
 
       def message
-        "Compatibility check is running. " \
+        "Lockfile saved. Compatibility check is running. " \
           "Wait ~#{@retry_after_seconds} seconds, then GET #{@status_url} to retrieve results. " \
           "Re-poll if status is still 'pending'."
       end

--- a/spec/controllers/api/lockfiles_controller_spec.rb
+++ b/spec/controllers/api/lockfiles_controller_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
     end
 
     context "with valid content" do
+      before { FactoryBot.create(:rails_release, version: "7.2") }
+
       it "creates a lockfile and returns 202 with slug, status, and polling instructions" do
         expect do
           post :create, params: { lockfile: { content: content } }, as: :json
@@ -66,6 +68,52 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
         expect(response).to have_http_status(:unprocessable_content)
         json = JSON.parse(response.body)
         expect(json["errors"]).to be_present
+      end
+    end
+
+    context "when the lockfile is already on the latest known Rails" do
+      it "returns 200 with errors and does not persist the lockfile" do
+        FactoryBot.create(:rails_release, version: "7.1")
+
+        expect do
+          post :create, params: { lockfile: { content: content } }, as: :json
+        end.not_to change(Lockfile, :count)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["errors"]).to be_present
+        expect(json["errors"].first).to match(/latest/i)
+      end
+    end
+
+    context "when the lockfile has no Rails dependency" do
+      let(:no_rails_content) do
+        <<~LOCK
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              puma (6.4.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            puma
+
+          BUNDLED WITH
+             2.4.10
+        LOCK
+      end
+
+      it "returns 422 with errors and does not persist the lockfile" do
+        expect do
+          post :create, params: { lockfile: { content: no_rails_content } }, as: :json
+        end.not_to change(Lockfile, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json = JSON.parse(response.body)
+        expect(json["errors"]).to be_present
+        expect(json["errors"].first).to match(/Rails/i)
       end
     end
   end

--- a/spec/controllers/api/lockfiles_controller_spec.rb
+++ b/spec/controllers/api/lockfiles_controller_spec.rb
@@ -36,10 +36,11 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
 
         json = JSON.parse(response.body)
         expect(json["slug"]).to eq(Lockfile.last.slug)
+        expect(json["reason"]).to eq("runnable")
         expect(json["status"]).to eq("pending")
         expect(json["retry_after_seconds"]).to be_a(Integer).and be_between(30, 600)
         expect(json["status_url"]).to include("/lockfiles/#{Lockfile.last.slug}")
-        expect(json["message"]).to include("GET")
+        expect(json["message"]).to include("Lockfile saved")
       end
 
       it "triggers run_check! on the lockfile" do
@@ -50,29 +51,31 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
     end
 
     context "with invalid content" do
-      it "returns 422 with errors" do
+      it "returns 422 with reason invalid_content and errors" do
         expect do
           post :create, params: { lockfile: { content: "not a lockfile" } }, as: :json
         end.not_to change(Lockfile, :count)
 
         expect(response).to have_http_status(:unprocessable_content)
         json = JSON.parse(response.body)
+        expect(json["reason"]).to eq("invalid_content")
         expect(json["errors"]).to be_present
       end
     end
 
     context "with missing content" do
-      it "returns 422 with errors" do
+      it "returns 422 with reason invalid_content and errors" do
         post :create, params: { lockfile: { content: "" } }, as: :json
 
         expect(response).to have_http_status(:unprocessable_content)
         json = JSON.parse(response.body)
+        expect(json["reason"]).to eq("invalid_content")
         expect(json["errors"]).to be_present
       end
     end
 
     context "when the lockfile is already on the latest known Rails" do
-      it "returns 200 with errors and does not persist the lockfile" do
+      it "returns 200 with reason up_to_date and errors, and does not persist the lockfile" do
         FactoryBot.create(:rails_release, version: "7.1")
 
         expect do
@@ -81,6 +84,7 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
 
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
+        expect(json["reason"]).to eq("up_to_date")
         expect(json["errors"]).to be_present
         expect(json["errors"].first).to match(/latest/i)
       end
@@ -105,13 +109,14 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
         LOCK
       end
 
-      it "returns 422 with errors and does not persist the lockfile" do
+      it "returns 422 with reason no_rails_dependency and errors, and does not persist the lockfile" do
         expect do
           post :create, params: { lockfile: { content: no_rails_content } }, as: :json
         end.not_to change(Lockfile, :count)
 
         expect(response).to have_http_status(:unprocessable_content)
         json = JSON.parse(response.body)
+        expect(json["reason"]).to eq("no_rails_dependency")
         expect(json["errors"]).to be_present
         expect(json["errors"].first).to match(/Rails/i)
       end

--- a/spec/controllers/lockfiles_controller_spec.rb
+++ b/spec/controllers/lockfiles_controller_spec.rb
@@ -80,6 +80,95 @@ RSpec.describe LockfilesController, type: :controller, vcr: { record: :once } do
         expect(flash[:alert]).to eq("Gemmies can't be blank. Content does not look like a valid lockfile.. Content No gems found in content.")
       end
     end
+
+    context "with the new check flow", new_check_flow: true do
+      let(:rails_content) do
+        <<~LOCK
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              rails (7.1.3)
+              puma (6.4.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            rails (= 7.1.3)
+            puma
+
+          BUNDLED WITH
+             2.4.10
+        LOCK
+      end
+
+      let(:no_rails_content) do
+        <<~LOCK
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              puma (6.4.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            puma
+
+          BUNDLED WITH
+             2.4.10
+        LOCK
+      end
+
+      context "when a next Rails release is available" do
+        before { FactoryBot.create(:rails_release, version: "7.2") }
+
+        it "creates the lockfile and redirects to its show page" do
+          expect do
+            post :create, params: { lockfile: { content: rails_content } }
+          end.to change(Lockfile, :count).by(1)
+
+          expect(response).to redirect_to(Lockfile.last)
+        end
+      end
+
+      context "when the lockfile is already on the latest known Rails" do
+        before { FactoryBot.create(:rails_release, version: "7.1") }
+
+        it "redirects back to the form with an alert and does not persist the lockfile" do
+          expect do
+            post :create, params: { lockfile: { content: rails_content } }
+          end.not_to change(Lockfile, :count)
+
+          expect(response).to redirect_to(new_lockfile_path)
+          expect(flash[:alert]).to be_present
+          expect(flash[:alert]).to match(/latest/i)
+        end
+      end
+
+      context "when the lockfile has no Rails dependency" do
+        it "redirects back to the form with an alert and does not persist the lockfile" do
+          expect do
+            post :create, params: { lockfile: { content: no_rails_content } }
+          end.not_to change(Lockfile, :count)
+
+          expect(response).to redirect_to(new_lockfile_path)
+          expect(flash[:alert]).to be_present
+          expect(flash[:alert]).to match(/Rails/i)
+        end
+      end
+
+      context "when the content is not a valid lockfile" do
+        it "redirects back to the form with an alert and does not persist the lockfile" do
+          expect do
+            post :create, params: { lockfile: { content: "not a lockfile" } }
+          end.not_to change(Lockfile, :count)
+
+          expect(response).to redirect_to(new_lockfile_path)
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
   end
 
   describe "GET #show" do

--- a/spec/controllers/lockfiles_controller_spec.rb
+++ b/spec/controllers/lockfiles_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe LockfilesController, type: :controller, vcr: { record: :once } do
       end
     end
 
-    context "with the new check flow", new_check_flow: true do
+    context "with the new check flow", new_check_flow: true, vcr: false do
       let(:rails_content) do
         <<~LOCK
           GEM

--- a/spec/models/lockfile/inspection_spec.rb
+++ b/spec/models/lockfile/inspection_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Lockfile::Inspection, type: :model do
+RSpec.describe Lockfile::Inspection, type: :model, new_check_flow: true do
   def lockfile_content(rails_version: "7.1.3")
     <<~LOCK
       GEM

--- a/spec/models/lockfile/inspection_spec.rb
+++ b/spec/models/lockfile/inspection_spec.rb
@@ -100,5 +100,13 @@ RSpec.describe Lockfile::Inspection, type: :model do
 
       expect(result.reason).to eq(:invalid_content)
     end
+
+    it "treats Bundler parse errors as invalid content" do
+      allow(Bundler::LockfileParser).to receive(:new).and_raise(Bundler::LockfileError, "boom")
+
+      result = described_class.call(lockfile_content)
+
+      expect(result.reason).to eq(:invalid_content)
+    end
   end
 end

--- a/spec/models/lockfile/inspection_spec.rb
+++ b/spec/models/lockfile/inspection_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+RSpec.describe Lockfile::Inspection, type: :model do
+  def lockfile_content(rails_version: "7.1.3")
+    <<~LOCK
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          rails (#{rails_version})
+          puma (6.4.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        rails (= #{rails_version})
+        puma
+
+      BUNDLED WITH
+         2.4.10
+    LOCK
+  end
+
+  def content_without_rails
+    <<~LOCK
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          puma (6.4.0)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        puma
+
+      BUNDLED WITH
+         2.4.10
+    LOCK
+  end
+
+  describe ".call" do
+    context "when the content does not look like a lockfile" do
+      it "returns reason :invalid_content" do
+        result = described_class.call("not a lockfile")
+
+        expect(result.reason).to eq(:invalid_content)
+        expect(result.message).to be_present
+        expect(result.http_status).to eq(:unprocessable_content)
+        expect(result.lockfile).to be_nil
+      end
+    end
+
+    context "when the lockfile has no Rails dependency" do
+      it "returns reason :no_rails_dependency" do
+        result = described_class.call(content_without_rails)
+
+        expect(result.reason).to eq(:no_rails_dependency)
+        expect(result.message).to be_present
+        expect(result.http_status).to eq(:unprocessable_content)
+        expect(result.lockfile).to be_nil
+      end
+    end
+
+    context "when the lockfile is already on the latest known Rails" do
+      it "returns reason :up_to_date" do
+        FactoryBot.create(:rails_release, version: "7.1")
+
+        result = described_class.call(lockfile_content(rails_version: "7.1.3"))
+
+        expect(result.reason).to eq(:up_to_date)
+        expect(result.message).to be_present
+        expect(result.http_status).to eq(:ok)
+        expect(result.lockfile).to be_nil
+      end
+    end
+
+    context "when there is a next Rails release available" do
+      it "returns reason :runnable with an unsaved Lockfile" do
+        FactoryBot.create(:rails_release, version: "7.2")
+
+        result = described_class.call(lockfile_content(rails_version: "7.1.3"))
+
+        expect(result.reason).to eq(:runnable)
+        expect(result.http_status).to eq(:accepted)
+        expect(result.lockfile).to be_a(Lockfile)
+        expect(result.lockfile).not_to be_persisted
+        expect(result.lockfile.content).to include("rails (7.1.3)")
+      end
+    end
+
+    it "trims leading and trailing whitespace before inspecting" do
+      result = described_class.call("\n\n  not a lockfile  \n")
+
+      expect(result.reason).to eq(:invalid_content)
+    end
+
+    it "treats blank input as invalid content" do
+      result = described_class.call("")
+
+      expect(result.reason).to eq(:invalid_content)
+    end
+  end
+end

--- a/spec/models/lockfile/inspection_spec.rb
+++ b/spec/models/lockfile/inspection_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe Lockfile::Inspection, type: :model do
       expect(result.reason).to eq(:invalid_content)
     end
 
+    it "treats model-level validation failures as invalid content" do
+      FactoryBot.create(:rails_release, version: "7.2")
+      allow_any_instance_of(Lockfile).to receive(:valid?).and_return(false)
+
+      result = described_class.call(lockfile_content)
+
+      expect(result.reason).to eq(:invalid_content)
+    end
+
     it "treats Bundler parse errors as invalid content" do
       allow(Bundler::LockfileParser).to receive(:new).and_raise(Bundler::LockfileError, "boom")
 


### PR DESCRIPTION
## Summary

Pre-flight a submitted `Gemfile.lock` through a new `Lockfile::Inspection` so
both the API and the web form can reject submissions we cannot act on
without saving anything. Closes the "infinite-pending" gap that was
called out as a known limitation in #208 (Mastodon-on-latest example).

`Lockfile::Inspection.call(content)` returns a small `Result` with one of
four reasons drawn from a centralized `REASONS` registry. Adding a new
reason in the future is a one-line entry in the table.

| reason | trigger | API | web |
|---|---|---|---|
| `runnable` | parses + has Rails + has next release + valid record | 202 + slug + polling instructions | redirect to lockfile show |
| `up_to_date` | parses + has Rails + no next release | 200 + `{ reason, errors: [msg] }` | flash alert + redirect to `new` |
| `no_rails_dependency` | parses + no Rails dep | 422 + `{ reason, errors: [msg] }` | flash alert + redirect to `new` |
| `invalid_content` | regex fails / Bundler raises / model invalid | 422 + `{ reason, errors: [msg] }` | flash alert + redirect to `new` |

Non-runnable submissions never reach the database.

## Notable details

- API responses now carry a top-level `reason` field (including the
  runnable case) so machine consumers can branch on a stable code
  instead of pattern-matching the human message.
- `Lockfile.valid_content?(str)` is the single shape check shared by
  the model's `validate_content` callback and `Inspection`.
- Inspection runs `lockfile.invalid?` itself, so the controllers can
  call `save!` once and trust the result. If `save!` ever raises after
  Inspection said `valid?`, that's a real bug worth surfacing.
- `Bundler::LockfileError` from a malformed-but-regex-matching content
  is mapped to `:invalid_content` instead of bubbling out as a 500.

## Test plan

- [x] `bundle exec rspec spec/models/lockfile/inspection_spec.rb` (8 examples, 0 failures)
- [x] `bundle exec rspec spec/controllers/api/lockfiles_controller_spec.rb` (9 examples, 0 failures)
- [x] `bundle exec rspec spec/controllers/lockfiles_controller_spec.rb -e "with the new check flow"` (4 examples, 0 failures)
- [x] All 95 model specs green
- [x] Manual: submit a Gemfile.lock with no Rails dep via `bin/api_check_lockfile` → 422 with `reason: "no_rails_dependency"`
- [x] Manual: submit a Gemfile.lock already on the latest known Rails → 200 with `reason: "up_to_date"`
- [x] Manual: submit garbage content → 422 with `reason: "invalid_content"`
- [x] Manual: web form rejects each non-runnable case with a flash alert and stays on `/lockfiles/new`

