### PR TITLE
Recognize railties-only Gemfile.lock files as Rails apps

### DIFF
--- a/app/models/lockfile/parsed.rb
+++ b/app/models/lockfile/parsed.rb
@@ -6,6 +6,26 @@ class Lockfile
   class Parsed
     RUBYGEMS_SOURCES = ["http://rubygems.org/", "https://rubygems.org/"]
 
+    # Rails core gems. Excluded from `#gems` because their compatibility with
+    # a target Rails release is determined by the Rails version itself, not
+    # by per-gem resolution — checking each individually would be redundant
+    # and noisy for apps that declare sub-gems directly (e.g. Discourse).
+    RAILS_GEMS = %w(
+      actioncable
+      actionmailbox
+      actionmailer
+      actionpack
+      actiontext
+      actionview
+      activejob
+      activemodel
+      activerecord
+      activestorage
+      activesupport
+      rails
+      railties
+    ).freeze
+
     LockedGem = Data.define(:name, :version, :source) do
       def resolvable?
         source.in?(RUBYGEMS_SOURCES) && version.present?
@@ -35,7 +55,7 @@ class Lockfile
     end
 
     def gems
-      @gems ||= parser.dependencies.keys.without("rails").map { |name| build_locked_gem(name) }
+      @gems ||= (parser.dependencies.keys - RAILS_GEMS).map { |name| build_locked_gem(name) }
     end
 
     private

--- a/app/models/lockfile/parsed.rb
+++ b/app/models/lockfile/parsed.rb
@@ -16,8 +16,14 @@ class Lockfile
       @parser = Bundler::LockfileParser.new(content)
     end
 
+    # Apps that skip the `rails` umbrella gem (Discourse, some API-only or
+    # extracted apps) declare `railties` directly. Either signals a Rails app
+    # and both stay in lockstep with the Rails version, so fall back to
+    # railties when rails itself is not a top-level spec.
     def rails_version
-      parser.specs.find { |s| s.name == "rails" }&.version&.to_s
+      spec = parser.specs.find { |s| s.name == "rails" } ||
+             parser.specs.find { |s| s.name == "railties" }
+      spec&.version&.to_s
     end
 
     def ruby_version

--- a/app/services/compats/checks/rails_gems_check.rb
+++ b/app/services/compats/checks/rails_gems_check.rb
@@ -5,21 +5,7 @@ module Compats::Checks
   #
   # If that's the case, the compat is marked as incompatible.
   class RailsGemsCheck < Base
-    RAILS_GEMS = %w(
-      actioncable
-      actionmailbox
-      actionmailer
-      actionpack
-      actiontext
-      actionview
-      activejob
-      activemodel
-      activerecord
-      activestorage
-      activesupport
-      rails
-      railties
-    )
+    RAILS_GEMS = Lockfile::Parsed::RAILS_GEMS
 
     def call
       return unless @compat.pending?

--- a/spec/models/lockfile/parsed_spec.rb
+++ b/spec/models/lockfile/parsed_spec.rb
@@ -124,6 +124,34 @@ RSpec.describe Lockfile::Parsed, type: :model, new_check_flow: true do
       expect(mystery_gem.version).to be_nil
       expect(mystery_gem.source).to be_nil
     end
+
+    it "excludes Rails core gems when they appear as top-level dependencies" do
+      content = <<~LOCK
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            actionpack (8.0.5)
+            activerecord (8.0.5)
+            railties (8.0.5)
+            puma (6.4.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          actionpack (~> 8.0.0)
+          activerecord (~> 8.0.0)
+          railties (~> 8.0.0)
+          puma
+
+        BUNDLED WITH
+           2.5.0
+      LOCK
+
+      parsed = described_class.new(content)
+
+      expect(parsed.gems.map(&:name)).to contain_exactly("puma")
+    end
   end
 
   describe Lockfile::Parsed::LockedGem do

--- a/spec/models/lockfile/parsed_spec.rb
+++ b/spec/models/lockfile/parsed_spec.rb
@@ -28,6 +28,28 @@ RSpec.describe Lockfile::Parsed, type: :model, new_check_flow: true do
       expect(parsed.rails_version).to eq("7.1.3")
     end
 
+    it "falls back to the railties version when rails is not declared directly" do
+      content = <<~LOCK
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            actionpack (8.0.5)
+            activerecord (8.0.5)
+            railties (8.0.5)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          railties (~> 8.0.0)
+
+        BUNDLED WITH
+           2.5.0
+      LOCK
+
+      expect(described_class.new(content).rails_version).to eq("8.0.5")
+    end
+
     it "returns nil when there is no rails spec" do
       content = <<~LOCK
         GEM


### PR DESCRIPTION
## Summary

Make `Lockfile::Parsed` handle Gemfile.lock files that declare `railties` directly (no `rails` umbrella gem). Two related changes:

1. **Detect `railties` as a Rails dependency.** Falls back to `railties` when `rails` is not a top-level spec, so `Lockfile#rails_version` returns the actual Rails version for railties-only apps.
2. **Exclude all 13 Rails core gems from per-lockfile gem checks**, not just `rails`. Apps that declare sub-gems explicitly (Discourse, etc.) currently get 13 redundant Sidekiq jobs per submission.

## Background

Some real-world Rails apps deliberately skip the `rails` meta-gem and pull in only the sub-gems they need. Discourse is the canonical example — its Gemfile declares `railties` plus `actionpack`, `activerecord`, `actionmailer`, etc. directly, never `rails` itself.

Two issues that affect the new lockfile flow:

- `Lockfile#rails_version` returned `nil` for these apps because it only matched a literal `rails` spec. Anything calling it (including the `Lockfile::Inspection` work in #210) sees no Rails version and treats the submission as a non-Rails app.
- Even after detection works, every Rails sub-gem listed in DEPENDENCIES becomes its own `GemCheck` and runs through `Checks::ResolveGem`. Rails core gems upgrade in lockstep — `actionpack 8.0` is always paired with `activerecord 8.0`, never independently — so the per-gem checks add no signal and waste worker time.

## Changes

### 1. `Lockfile::Parsed#rails_version` falls back to `railties`

```ruby
def rails_version
  spec = parser.specs.find { |s| s.name == "rails" } ||
         parser.specs.find { |s| s.name == "railties" }
  spec&.version&.to_s
end
```

`railties` is the canonical core gem and stays in lockstep with the umbrella version on every release.

### 2. `Lockfile::Parsed#gems` excludes all Rails core gems

Extracted to `Lockfile::Parsed::RAILS_GEMS` (the 13 sub-gems) and reused from `Compats::Checks::RailsGemsCheck` so the two stay in sync. `gems` now subtracts the whole list instead of just `["rails"]`.

## Verification

Against the live Discourse lockfile (~150 deps, declares each Rails sub-gem):

```sh
$ curl -sS https://raw.githubusercontent.com/discourse/discourse/refs/heads/main/Gemfile.lock -o /tmp/discourse.lock
$ bundle exec rails runner 'r = Lockfile::Inspection.call(File.read("/tmp/discourse.lock")); puts r.reason; puts r.lockfile.gems.size'
runnable
~140  # was ~150 before, since the 13 Rails core gems are now filtered out
```

Was `:no_rails_dependency` before this PR; now `:runnable` with the noisy Rails sub-gem checks suppressed.

## Test plan

- [x] `bundle exec rspec spec/models/lockfile/parsed_spec.rb` (15 examples, 0 failures)
- [x] All 97 model specs green
- [x] Manual: live POST of Discourse lockfile via `bin/api_check_lockfile` returns 202 with `reason: "runnable"`
- [x] Manual: GemChecks created for the submission no longer include Rails core gems
