### PR TITLE
Temporarily disable legacy checker flow + add Sentry observability

### DIFF
--- a/app/controllers/api/github_notifications_controller.rb
+++ b/app/controllers/api/github_notifications_controller.rb
@@ -1,18 +1,23 @@
 module API
   class GithubNotificationsController < BaseController
     def create
-      data = request.request_parameters
-
-      github_notification = GithubNotification.create!(
-        data:       data,
-        action:     data["action"],
-        conclusion: data.dig("check_run", "conclusion"),
-        branch:     data.dig("check_run", "check_suite", "head_branch")
+      Sentry.capture_message(
+        "POST /api/github_notifications hit while temporarily disabled",
+        level: :info,
+        extra: {
+          action:     request.request_parameters["action"],
+          conclusion: request.request_parameters.dig("check_run", "conclusion"),
+          branch:     request.request_parameters.dig("check_run", "check_suite", "head_branch"),
+          remote_ip:  request.remote_ip,
+          user_agent: request.user_agent,
+          referer:    request.referer
+        }
       )
 
-      GithubNotifications::Process.perform_async github_notification.id
-
-      head :ok
+      render json: {
+        error: "temporarily_disabled",
+        message: "POST /api/github_notifications is temporarily disabled."
+      }, status: :service_unavailable
     end
   end
 end

--- a/app/controllers/api/releases_controller.rb
+++ b/app/controllers/api/releases_controller.rb
@@ -1,17 +1,22 @@
 module API
   class ReleasesController < BaseController
     def create
-      name = params.fetch(:name)
-
-      if name == "rails"
-        RailsReleases::Create.perform_async params.fetch(:version)
-      else
-        Gemmy.find_by_name(name)&.then {
-          Gemmies::Process.perform_async _1.id
+      Sentry.capture_message(
+        "POST /api/releases hit while temporarily disabled",
+        level: :info,
+        extra: {
+          name: params[:name],
+          version: params[:version],
+          remote_ip: request.remote_ip,
+          user_agent: request.user_agent,
+          referer: request.referer
         }
-      end
+      )
 
-      head :ok
+      render json: {
+        error: "temporarily_disabled",
+        message: "POST /api/releases is temporarily disabled."
+      }, status: :service_unavailable
     end
   end
 end

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,5 +1,7 @@
 module API
   class ResultsController < BaseController
+    before_action :authenticate_api_key!
+
     def create
       Sentry.capture_message(
         "POST /api/results hit while temporarily disabled",
@@ -8,7 +10,7 @@ module API
           compat_id:     params[:compat_id],
           rails_version: params[:rails_version],
           strategy:      params.dig(:result, :strategy),
-          api_key_name:  request.headers['RAILS-BUMP-API-KEY'].present? ? "<present>" : nil,
+          api_key_name:  @api_key&.name,
           remote_ip:     request.remote_ip,
           user_agent:    request.user_agent,
           referer:       request.referer
@@ -17,8 +19,26 @@ module API
 
       render json: {
         error: "temporarily_disabled",
-        message: "POST /api/results is temporarily disabled."
+        message: "POST /api/results is temporarily disabled while we investigate a memory issue."
       }, status: :service_unavailable
+    end
+
+    private
+
+    def authenticate_api_key!
+      api_key = request.headers['RAILS-BUMP-API-KEY']
+
+      return head :unauthorized if invalid_api_key?(api_key)
+
+      logger.info "API Key: #{@api_key.name}"
+    end
+
+    def invalid_api_key?(api_key)
+      return true if api_key.nil?
+
+      @api_key = APIKey.find_by(key: api_key)
+
+      return true if @api_key.nil?
     end
   end
 end

--- a/app/controllers/api/results_controller.rb
+++ b/app/controllers/api/results_controller.rb
@@ -1,54 +1,24 @@
 module API
   class ResultsController < BaseController
-    before_action :authenticate_api_key!
-    before_action :sanitize_result_params!, only: :create
-
     def create
-      @rails_release = RailsRelease.find_by(version: params[:rails_version])
-      @compat = @rails_release.compats.find_by_id!(params[:compat_id])
+      Sentry.capture_message(
+        "POST /api/results hit while temporarily disabled",
+        level: :info,
+        extra: {
+          compat_id:     params[:compat_id],
+          rails_version: params[:rails_version],
+          strategy:      params.dig(:result, :strategy),
+          api_key_name:  request.headers['RAILS-BUMP-API-KEY'].present? ? "<present>" : nil,
+          remote_ip:     request.remote_ip,
+          user_agent:    request.user_agent,
+          referer:       request.referer
+        }
+      )
 
-      if @compat.dependencies == params.require(:dependencies).permit!.to_h
-        if @compat.process_result(params[:result])
-          logger.info "Compat #{@compat.id} processed successfully"
-          head :ok
-        else
-          logger.info "Compat #{@compat.id} process_result failed: #{@compat.errors.full_messages}"
-          head :unprocessable_content
-        end
-      else
-        logger.info "Compat #{@compat.id} dependencies do not match"
-        head :unprocessable_content
-      end
-    end
-
-    private
-
-    def sanitize_result_params!
-      if params[:result].is_a?(ActionController::Parameters)
-        # PROBE: capture :output size, then drop it entirely to test the
-        # web-dyno memory leak hypothesis. Revert once confirmed.
-        params[:result].delete(:output)
-        params[:result].each_key do |key|
-          value = params[:result][key]
-          params[:result][key] = value.delete("\x00") if value.is_a?(String)
-        end
-      end
-    end
-
-    def authenticate_api_key!
-      api_key = request.headers['RAILS-BUMP-API-KEY']
-
-      return head :unauthorized if invalid_api_key?(api_key)
-
-      logger.info "API Key: #{@api_key.name}"
-    end
-
-    def invalid_api_key?(api_key)
-      return true if api_key.nil?
-
-      @api_key = APIKey.find_by(key: api_key)
-
-      return true if @api_key.nil?
+      render json: {
+        error: "temporarily_disabled",
+        message: "POST /api/results is temporarily disabled."
+      }, status: :service_unavailable
     end
   end
 end

--- a/app/controllers/gemmies_controller.rb
+++ b/app/controllers/gemmies_controller.rb
@@ -4,6 +4,17 @@ class GemmiesController < ApplicationController
   end
 
   def create
+    Sentry.capture_message(
+      "POST /gems hit (legacy gem submission)",
+      level: :info,
+      extra: {
+        name:       gemmy_params[:name],
+        remote_ip:  request.remote_ip,
+        user_agent: request.user_agent,
+        referer:    request.referer
+      }
+    )
+
     @gemmy = Gemmies::Create.call(gemmy_params.fetch(:name))
   rescue Gemmies::Create::AlreadyExists => error
     redirect_to error.gemmy,
@@ -24,6 +35,19 @@ class GemmiesController < ApplicationController
   end
 
   def show
+    if rand < 0.01
+      Sentry.capture_message(
+        "GET /gems/:id hit (legacy gem page, 1% sample)",
+        level: :info,
+        extra: {
+          name:       params[:id],
+          remote_ip:  request.remote_ip,
+          user_agent: request.user_agent,
+          referer:    request.referer
+        }
+      )
+    end
+
     @gemmy = Gemmy.find_by_name(params[:id])
 
     if @gemmy
@@ -40,6 +64,18 @@ class GemmiesController < ApplicationController
   end
 
   def compat_table
+    Sentry.capture_message(
+      "GET /gems/compat_table hit (legacy)",
+      level: :info,
+      extra: {
+        gemmy_ids:             params[:gemmy_ids],
+        inaccessible_gemmy_ids: params[:inaccessible_gemmy_ids],
+        remote_ip:             request.remote_ip,
+        user_agent:            request.user_agent,
+        referer:               request.referer
+      }
+    )
+
     render locals: {
       gemmies: Gemmy.find(gemmy_ids),
       inaccessible_gemmies: InaccessibleGemmy.find(inaccessible_gemmy_ids),

--- a/app/controllers/rails_releases_controller.rb
+++ b/app/controllers/rails_releases_controller.rb
@@ -1,5 +1,19 @@
 class RailsReleasesController < ApplicationController
   def show
+    if rand < 0.01
+      Sentry.capture_message(
+        "GET /gems/:gemmy_id/compatibility/:id hit (legacy compat page, 1% sample)",
+        level: :info,
+        extra: {
+          gemmy_id:   params[:gemmy_id],
+          rails_id:   params[:id],
+          remote_ip:  request.remote_ip,
+          user_agent: request.user_agent,
+          referer:    request.referer
+        }
+      )
+    end
+
     @gemmy = Gemmy.find_by_name!(params[:gemmy_id])
     @rails_release = RailsRelease.find_by!(version: params[:id].gsub("rails-", "").gsub("-", "."))
   end

--- a/app/views/gemmies/index.html.haml
+++ b/app/views/gemmies/index.html.haml
@@ -28,14 +28,16 @@
               = link_to "Rails Upgrade Services", "https://www.fastruby.io?utm_source=railsbump", target: "_blank"
 
 %section
-  = link_to "Check a gem", %i(new gemmy), class: "btn btn-primary"
-  or
+  - unless FeatureFlags.new_check_flow?
+    = link_to "Check a gem", %i(new gemmy), class: "btn btn-primary"
+    or
   = link_to "Check a lockfile", %i(new lockfile), class: "btn btn-primary"
 
-%section
-  %h2
-    Latest checked gems
-  = render template: "gemmies/compat_table", locals: { gemmies: @gemmies, inaccessible_gemmies: @inaccessible_gemmies }
+- unless FeatureFlags.new_check_flow?
+  %section
+    %h2
+      Latest checked gems
+    = render template: "gemmies/compat_table", locals: { gemmies: @gemmies, inaccessible_gemmies: @inaccessible_gemmies }
 
 %section
   %h2

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,6 +2,6 @@
   = navbar container: "lg", expand_at: "md", bg: "dark", brand: "👊 RailsBump" do
     = navbar_collapse class: "justify-content-end" do
       = navbar_group do
-        = navbar_item "Check a gem", new_gemmy_path
+        = navbar_item "Check a gem", new_gemmy_path unless FeatureFlags.new_check_flow?
         = navbar_item "Check a lockfile", new_lockfile_path
         = navbar_item tag.i(class: %w(fab fa-github)), "https://github.com/railsbump/app", {}, target: "_blank"

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,4 +3,6 @@ Sentry.init do |config|
   config.include_local_variables = true
   config.release                 = Rails.configuration.revision
   config.send_default_pii        = true
+  config.traces_sample_rate      = 0.05
+  config.profiles_sample_rate    = 0.05
 end

--- a/spec/controllers/api/github_notifications_controller_spec.rb
+++ b/spec/controllers/api/github_notifications_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-RSpec.describe API::GithubNotificationsController, type: :controller do
+# Disabled while POST /api/github_notifications is temporarily turned off as part
+# of the memory leak investigation. Re-enable after the endpoint behavior is restored.
+RSpec.xdescribe API::GithubNotificationsController, type: :controller do
   describe "POST #create" do
     # Realistic GitHub Check Run webhook payload structure
     let(:notification_data) do

--- a/spec/controllers/api/releases_controller_spec.rb
+++ b/spec/controllers/api/releases_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-RSpec.describe API::ReleasesController, type: :controller do
+# Disabled while POST /api/releases is temporarily turned off as part of the
+# memory leak investigation. Re-enable after the endpoint behavior is restored.
+RSpec.xdescribe API::ReleasesController, type: :controller do
   describe "POST #create" do
     context "when name is 'rails'" do
       before { allow(RailsReleases::Create).to receive(:perform_async) }

--- a/spec/controllers/api/results_controller_spec.rb
+++ b/spec/controllers/api/results_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe API::ResultsController, type: :controller do
+# Disabled while POST /api/results is temporarily turned off as part of the
+# memory leak investigation. Re-enable after the endpoint behavior is restored.
+RSpec.xdescribe API::ResultsController, type: :controller do
   let(:api_key) { FactoryBot.create(:api_key) }
   let(:rails_release) { FactoryBot.create(:rails_release) }
   let(:compat) { FactoryBot.create(:compat, rails_release: rails_release, status: :pending) }


### PR DESCRIPTION
## Summary

Temporarily disable the legacy GH-Actions checker flow at the API edge so we can isolate whether the new lockfile flow is the source of the production memory leak. Adds Sentry tracking on every disabled endpoint and on the remaining legacy gem pages so we can identify any caller.

## Background

PRs #199, #200, #203 and railsbump/checker#40 reduced the leak meaningfully but did not close it. Heroku metrics for the most recent weekend show AVG 873 MB / MAX 1335 MB on web.1 against a 1024 MB quota, with R14 errors firing repeatedly.

On Apr 30 we measured a clean +14 MB step on web.1 RSS for each `POST /lockfiles` upload that did not reclaim, while quiet windows of pure crawler traffic stayed flat. That points the next investigation at the new lockfile flow.

To make that investigation clean, this PR removes the legacy flow as a confound. The legacy chain runs through:

- `POST /api/releases`             → `RailsReleases::Create.perform_async` / `Gemmies::Process.perform_async`
- `POST /api/github_notifications` → `GithubNotification.create!` + `GithubNotifications::Process.perform_async`
- `POST /api/results`              → tail of the GH Actions check pipeline
- The Heroku Scheduler entry running `bin/rails runner "Compats::CheckUnchecked.call"` every 10 min (must be disabled separately in the Heroku UI; no CLI for that)

After this PR plus the scheduler removal, the only flow producing checker work is `Lockfile#run_check!` on `POST /lockfiles`.

## Manual steps required after merge

```bash
# 1. Remove the Heroku Scheduler entry (no CLI for this addon)
heroku addons:open scheduler -a railsbump-production
# Delete the row "bin/rails runner Compats::CheckUnchecked.call"
# Leave the "bin/rails runner Maintenance::Hourly.call" row alone — it's
# orthogonal (sitemap regen, email notifications, cleanup). One nuisance:
# its check_pending_compats helper will start reporting "compats pending
# for a long time" since CheckUnchecked is off. If those alerts get noisy,
# comment that private method out in app/services/maintenance/hourly.rb.

# 2. Disable the GH Actions checker workflows in railsbump/checker
gh workflow disable check_bundler.yml -R railsbump/checker
gh workflow disable rails_release_sanity_check.yml -R railsbump/checker
# Belt-and-suspenders: prevents accidental dispatches even if the
# scheduler entry is restored or someone calls BundlerGithubCheck directly.
# Re-enable later with `gh workflow enable <file> -R railsbump/checker`.
```

## What this PR is not

Not a fix. The leak measurement points at the lockfile flow; this PR only removes the legacy flow as a possible confound and gives us observability on what is still calling those endpoints. The leak hunt continues in a follow-up PR (planned: per-request memory delta middleware to attribute RSS retention to a specific path).

## Test plan

- [ ] Deploy to staging, hit each disabled endpoint, confirm 503 + Sentry event arrives.
- [ ] Open Sentry → Performance, confirm transactions appear at ~5% sample.
- [ ] Remove the Heroku Scheduler entry.
- [ ] Watch Sentry inbox for `temporarily_disabled` messages over 24h to identify callers.
- [ ] Watch web.1 RSS curve for slope change vs. last week.

## Related

- #199, #200, #203 — earlier rounds (worker batches, drop `:output` persistence, jemalloc Procfile wrap)
- railsbump/checker#40 — checker stopped sending `:output`
- `notes/memory-leak-watch.md` — full data trail across the investigation
