### PR TITLE
Pin connection_pool to ~> 2.5 to fix boot failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
     cgi (0.5.1)
     choice (0.2.0)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.0)
       bigdecimal
       rexml


### PR DESCRIPTION
## Problem

Deploy failed during \`rake assets:precompile\`:

\`\`\`
ArgumentError: wrong number of arguments (given 1, expected 0)
  connection_pool-3.0.2 ConnectionPool#initialize
\`\`\`

\`connection_pool 3.0.2\` changed \`initialize\` to keyword-only arguments, removing the positional hash form. \`activesupport 8.0.3\` still calls \`ConnectionPool.new(pool_options)\` with a positional hash, which breaks on boot.

This was introduced by \`bundle update sentry-ruby sentry-rails sentry-sidekiq\` which transitively bumped \`connection_pool\` from \`2.5.4\` to \`3.0.2\`.

## Fix

Re-ran \`bundle update sentry-ruby sentry-rails sentry-sidekiq --conservative\` to keep \`connection_pool\` at \`2.5.5\` (closest to original \`2.5.4\`) without adding an explicit Gemfile entry. The lockfile constraint is sufficient — no direct dependency needed.

Boot verified locally. \`Gemfile.next.lock\` was already at \`2.5.4\` and required no changes.

Note: \`connection_pool 3.0.2\` release notes mention a backwards-compat fix for \`:name\` keyword (issue #210) but that is unrelated — the breaking change is the broader positional→keyword-only \`initialize\` API change introduced in 3.0.