### PR TITLE
Auto-select scheme in api_check_lockfile and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Check your Ruby gems for compatibility with all Rails minor versions.
 
 The app is live at https://railsbump.org/, where you can check an [individual gem](http://railsbump.org/gems/new) or a [whole Bundler lockfile](http://railsbump.org/lockfiles/new) (Gemfile.lock).
 
+You can also submit a `Gemfile.lock` from the shell with the [`bin/api_check_lockfile`](bin/api_check_lockfile) helper, which wraps the `POST /lockfiles` and `GET /lockfiles/:slug` JSON endpoints. Scheme auto-selects (`http` for `localhost`, `https` otherwise). See [`docs/api_check_lockfile.md`](docs/api_check_lockfile.md) for full usage.
+
 ## Behind the scenes
 
 RailsBump uses a few approaches to check whether a gem version is compatible with a specific Rails release:

--- a/bin/api_check_lockfile
+++ b/bin/api_check_lockfile
@@ -7,11 +7,18 @@
 #
 # Override host with API_HOST (default: api.localhost:3000):
 #   API_HOST=api.railsbump.org bin/api_check_lockfile Gemfile.lock
+#
+# Scheme auto-selects: https for api.railsbump.org, http for localhost.
+# Override with API_SCHEME if needed.
 
 set -euo pipefail
 
 HOST="${API_HOST:-api.localhost:3000}"
-SCHEME="${API_SCHEME:-http}"
+case "$HOST" in
+  *localhost*|127.0.0.1*) DEFAULT_SCHEME="http" ;;
+  *)                      DEFAULT_SCHEME="https" ;;
+esac
+SCHEME="${API_SCHEME:-$DEFAULT_SCHEME}"
 BASE="${SCHEME}://${HOST}"
 
 usage() {

--- a/docs/api_check_lockfile.md
+++ b/docs/api_check_lockfile.md
@@ -73,10 +73,18 @@ Top-level `status` flips to `"complete"` once every nested
 
 ## Hitting a non-local environment
 
-Set `API_HOST` (and optionally `API_SCHEME`):
+Set `API_HOST`:
 
 ```sh
-API_HOST=api.railsbump.org API_SCHEME=https \
+API_HOST=api.railsbump.org bin/api_check_lockfile path/to/Gemfile.lock
+```
+
+Scheme auto-selects based on the host: `http` for `localhost`/`127.0.0.1`,
+`https` for everything else. Override with `API_SCHEME` only if needed
+(e.g. hitting a remote host over plain HTTP for debugging):
+
+```sh
+API_HOST=staging.example.com API_SCHEME=http \
   bin/api_check_lockfile path/to/Gemfile.lock
 ```
 


### PR DESCRIPTION
## Summary

- `bin/api_check_lockfile` now auto-selects `http` for `localhost`/`127.0.0.1` and `https` for any other host, so the common `API_HOST=api.railsbump.org …` invocation no longer needs an explicit `API_SCHEME=https`.
- `API_SCHEME` is still honored as an override for edge cases (e.g. a remote host over plain HTTP).
- Updated `docs/api_check_lockfile.md` to match: simpler non-local example, plus a note describing the auto-select behavior and when to override.
