### PR TITLE
Fix lockfile show page not updating via Turbo

### DIFF
--- a/app/jobs/lockfiles/start_check.rb
+++ b/app/jobs/lockfiles/start_check.rb
@@ -11,6 +11,14 @@ module Lockfiles
 
       lockfile_check = LockfileCheck.create_for!(lockfile: lockfile, rails_release: rails_release)
       lockfile_check.enqueue_gem_checks
+
+      lockfile.lockfile_checks.reload
+      Turbo::StreamsChannel.broadcast_replace_to(
+        lockfile, :gem_checks,
+        target: ActionView::RecordIdentifier.dom_id(lockfile, :checks),
+        partial: "lockfiles/checks_container",
+        locals: { lockfile: lockfile }
+      )
     end
   end
 end

--- a/app/views/lockfiles/_checks_container.html.erb
+++ b/app/views/lockfiles/_checks_container.html.erb
@@ -1,0 +1,13 @@
+<div id="<%= dom_id(lockfile, :checks) %>">
+  <% lockfile.lockfile_checks.each do |lockfile_check| %>
+    <%= render "lockfiles/lockfile_check_section", lockfile_check: lockfile_check %>
+  <% end %>
+
+  <% if lockfile.lockfile_checks.empty? %>
+    <section class="mt-4">
+      <div class="alert alert-info">
+        Your lockfile is being processed&hellip; results will appear here shortly.
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/app/views/lockfiles/_lockfile_check_section.html.erb
+++ b/app/views/lockfiles/_lockfile_check_section.html.erb
@@ -1,0 +1,57 @@
+<section class="mt-4">
+  <div class="row mb-3">
+    <div class="col-md-6 order-2 order-md-1">
+      <table class="table table-sm table-hover mb-0" style="cursor: pointer;">
+        <tbody>
+          <tr>
+            <th scope="row">Target Rails</th>
+            <td class="text-end"><%= lockfile_check.rails_release.version %></td>
+          </tr>
+          <tr>
+            <th scope="row">Ruby</th>
+            <td class="text-end"><%= lockfile_check.ruby_version %></td>
+          </tr>
+          <tr>
+            <th scope="row">Bundler</th>
+            <td class="text-end"><%= lockfile_check.bundler_version %></td>
+          </tr>
+          <tr>
+            <th scope="row">RubyGems</th>
+            <td class="text-end"><%= lockfile_check.rubygems_version %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="col-md-6 order-1 order-md-2 d-flex align-items-center mb-3 mb-md-0">
+      <p class="text-muted small mb-0">
+        Ruby and Bundler come from the <code>Gemfile.lock</code> you provided,
+        unless the target Rails version requires a newer minimum, in which
+        case we use that minimum instead. RubyGems is derived from the chosen
+        Ruby version.
+      </p>
+    </div>
+  </div>
+
+  <div class="d-flex align-items-center gap-2 mb-3">
+    <h2 class="mb-0">Compatibility with Rails <%= lockfile_check.rails_release.version %></h2>
+    <%= render "lockfile_checks/status_badge", lockfile_check: lockfile_check %>
+  </div>
+
+  <% if lockfile_check.gem_checks.any? %>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Gem</th>
+            <th>Locked Version</th>
+            <th>Result</th>
+            <th style="width: 30%;">Earliest Compatible</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "gem_checks/gem_check", collection: lockfile_check.gem_checks.order(:gem_name) %>
+        </tbody>
+      </table>
+    </div>
+  <% end %>
+</section>

--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -10,73 +10,7 @@
 
 <%= turbo_stream_from @lockfile, :gem_checks %>
 
-<% @lockfile.lockfile_checks.each do |lockfile_check| %>
-  <section class="mt-4">
-    <div class="row mb-3">
-      <div class="col-md-6 order-2 order-md-1">
-        <table class="table table-sm table-hover mb-0" style="cursor: pointer;">
-          <tbody>
-            <tr>
-              <th scope="row">Target Rails</th>
-              <td class="text-end"><%= lockfile_check.rails_release.version %></td>
-            </tr>
-            <tr>
-              <th scope="row">Ruby</th>
-              <td class="text-end"><%= lockfile_check.ruby_version %></td>
-            </tr>
-            <tr>
-              <th scope="row">Bundler</th>
-              <td class="text-end"><%= lockfile_check.bundler_version %></td>
-            </tr>
-            <tr>
-              <th scope="row">RubyGems</th>
-              <td class="text-end"><%= lockfile_check.rubygems_version %></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="col-md-6 order-1 order-md-2 d-flex align-items-center mb-3 mb-md-0">
-        <p class="text-muted small mb-0">
-          Ruby and Bundler come from the <code>Gemfile.lock</code> you provided,
-          unless the target Rails version requires a newer minimum, in which
-          case we use that minimum instead. RubyGems is derived from the chosen
-          Ruby version.
-        </p>
-      </div>
-    </div>
-
-    <div class="d-flex align-items-center gap-2 mb-3">
-      <h2 class="mb-0">Compatibility with Rails <%= lockfile_check.rails_release.version %></h2>
-      <%= render "lockfile_checks/status_badge", lockfile_check: lockfile_check %>
-    </div>
-
-    <% if lockfile_check.gem_checks.any? %>
-      <div class="table-responsive">
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th>Gem</th>
-              <th>Locked Version</th>
-              <th>Result</th>
-              <th style="width: 30%;">Earliest Compatible</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= render partial: "gem_checks/gem_check", collection: lockfile_check.gem_checks.order(:gem_name) %>
-          </tbody>
-        </table>
-      </div>
-    <% end %>
-  </section>
-<% end %>
-
-<% if @lockfile.lockfile_checks.empty? %>
-  <section class="mt-4">
-    <div class="alert alert-info">
-      No checks have been run for this lockfile yet.
-    </div>
-  </section>
-<% end %>
+<%= render "lockfiles/checks_container", lockfile: @lockfile %>
 
 <div id="lockfile-content-modal" class="modal fade">
   <div class="modal-dialog modal-dialog-scrollable modal-lg">


### PR DESCRIPTION
## Summary

- After #216 deferred `run_check!` to Sidekiq, the lockfile show page rendered before any `LockfileCheck` or `GemCheck` rows existed in the DB
- The page showed a blue "No checks have been run" alert; `ResolveGem` then broadcast updates to `dom_id(gem_check)` targets that were never in the DOM, so results only appeared after a manual refresh
- Fix: broadcast a full replace of the checks container from `StartCheck` right after `create_for!`, so all `<tr id="gem_check_XYZ">` rows are rendered before individual resolve-gem broadcasts fire

## Changes

- Extract `_checks_container.html.erb` and `_lockfile_check_section.html.erb` partials from inline `show_new.html.erb`
- Wrap checks area in `<div id="lockfile_X_checks">` as a stable Turbo broadcast target
- `StartCheck#perform` reloads the association and broadcasts `broadcast_replace_to` after `create_for!` + `enqueue_gem_checks`
- Update "no checks" message to "Your lockfile is being processed..." so users know work is underway

## Test plan

- Upload a Gemfile.lock with a Rails 7.x dependency via the UI
- Confirm the show page immediately renders the checks section with "Checking..." badge (no blue alert)
- Confirm individual gem rows update in place as `ResolveGem` jobs complete (no refresh needed)