### PR TITLE
Update lockfile waiting message to reflect queued state

### DIFF
--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -73,7 +73,7 @@
 <% if @lockfile.lockfile_checks.empty? %>
   <section class="mt-4">
     <div class="alert alert-info">
-      No checks have been run for this lockfile yet.
+      Checks are queued and running. Results will appear here automatically once they're ready.
     </div>
   </section>
 <% end %>

--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -73,7 +73,7 @@
 <% if @lockfile.lockfile_checks.empty? %>
   <section class="mt-4">
     <div class="alert alert-info">
-      Checks are queued and running. Results will appear here automatically once they're ready.
+      Results will appear here automatically as they are processed.
     </div>
   </section>
 <% end %>


### PR DESCRIPTION
## What

Updates the empty-state message shown on a lockfile page when no checks have completed yet.

Before:

> No checks have been run for this lockfile yet.

After:

> Checks are queued and running. Results will appear here automatically once they're ready.

## Why

The old wording implied nothing was happening. With Sidekiq concurrency at 2, checks drain gradually, so the lockfile is actually queued and being processed, just not instantly.

The new message conveys that checks are running and results will appear automatically. It intentionally does not tell the user to refresh, since live auto-updating of the page is handled in a separate ticket.


## Screenshot

<img width="820" height="361" alt="Screenshot 2026-06-01 at 9 07 53" src="https://github.com/user-attachments/assets/d6c78a2a-c478-41c2-9f66-8d7e98c2baa7" />


Closes #223
