### PR TITLE
Live-render lockfile checks via Turbo broadcast

### DIFF
--- a/app/jobs/lockfiles/start_check.rb
+++ b/app/jobs/lockfiles/start_check.rb
@@ -10,6 +10,7 @@ module Lockfiles
       return unless rails_release
 
       lockfile_check = LockfileCheck.create_for!(lockfile: lockfile, rails_release: rails_release)
+      lockfile.broadcast_checks
       lockfile_check.enqueue_gem_checks
     end
   end

--- a/app/models/lockfile.rb
+++ b/app/models/lockfile.rb
@@ -50,6 +50,19 @@ class Lockfile < ApplicationRecord
     Compat.where(id: gemmies.flat_map(&:compat_ids))
   end
 
+  # Re-renders the whole #lockfile_checks container over Turbo Streams.
+  # Used instead of granular replaces so the target always exists: subscribers
+  # render the container on initial load, and every broadcast rebuilds it from
+  # the current DB state (sections appear, rows update, empty-state clears).
+  def broadcast_checks
+    broadcast_replace_to(
+      [self, :gem_checks],
+      target: "lockfile_checks",
+      partial: "lockfiles/checks",
+      locals: { lockfile: self }
+    )
+  end
+
   def gem_names
     parser = Bundler::LockfileParser.new(content)
     parser.dependencies.keys - %w(rails)

--- a/app/models/lockfile.rb
+++ b/app/models/lockfile.rb
@@ -50,10 +50,6 @@ class Lockfile < ApplicationRecord
     Compat.where(id: gemmies.flat_map(&:compat_ids))
   end
 
-  # Re-renders the whole #lockfile_checks container over Turbo Streams.
-  # Used instead of granular replaces so the target always exists: subscribers
-  # render the container on initial load, and every broadcast rebuilds it from
-  # the current DB state (sections appear, rows update, empty-state clears).
   def broadcast_checks
     broadcast_replace_to(
       self, :gem_checks,

--- a/app/models/lockfile.rb
+++ b/app/models/lockfile.rb
@@ -56,7 +56,7 @@ class Lockfile < ApplicationRecord
   # the current DB state (sections appear, rows update, empty-state clears).
   def broadcast_checks
     broadcast_replace_to(
-      [self, :gem_checks],
+      self, :gem_checks,
       target: "lockfile_checks",
       partial: "lockfiles/checks",
       locals: { lockfile: self }

--- a/app/services/checks/resolve_gem.rb
+++ b/app/services/checks/resolve_gem.rb
@@ -11,16 +11,34 @@ module Checks
       gem_check.perform!
 
       lockfile_check = gem_check.lockfile_check
+      broadcast_gem_check(gem_check)
       mark_lockfile_check_complete(lockfile_check)
-      lockfile_check.lockfile.broadcast_checks
     end
 
     private
+
+    def broadcast_gem_check(gem_check)
+      lockfile = gem_check.lockfile_check.lockfile
+
+      Turbo::StreamsChannel.broadcast_replace_to(
+        lockfile, :gem_checks,
+        target: ActionView::RecordIdentifier.dom_id(gem_check),
+        partial: "gem_checks/gem_check",
+        locals: { gem_check: gem_check }
+      )
+    end
 
     def mark_lockfile_check_complete(lockfile_check)
       return if lockfile_check.gem_checks.where(status: "pending").exists?
 
       lockfile_check.update!(status: "complete")
+
+      Turbo::StreamsChannel.broadcast_replace_to(
+        lockfile_check.lockfile, :gem_checks,
+        target: ActionView::RecordIdentifier.dom_id(lockfile_check, :status),
+        partial: "lockfile_checks/status_badge",
+        locals: { lockfile_check: lockfile_check }
+      )
     end
   end
 end

--- a/app/services/checks/resolve_gem.rb
+++ b/app/services/checks/resolve_gem.rb
@@ -10,9 +10,8 @@ module Checks
       gem_check = GemCheck.find(gem_check_id)
       gem_check.perform!
 
-      lockfile_check = gem_check.lockfile_check
       broadcast_gem_check(gem_check)
-      mark_lockfile_check_complete(lockfile_check)
+      mark_lockfile_check_complete(gem_check.lockfile_check)
     end
 
     private

--- a/app/services/checks/resolve_gem.rb
+++ b/app/services/checks/resolve_gem.rb
@@ -10,34 +10,17 @@ module Checks
       gem_check = GemCheck.find(gem_check_id)
       gem_check.perform!
 
-      broadcast_gem_check(gem_check)
-      mark_lockfile_check_complete(gem_check.lockfile_check)
+      lockfile_check = gem_check.lockfile_check
+      mark_lockfile_check_complete(lockfile_check)
+      lockfile_check.lockfile.broadcast_checks
     end
 
     private
-
-    def broadcast_gem_check(gem_check)
-      lockfile = gem_check.lockfile_check.lockfile
-
-      Turbo::StreamsChannel.broadcast_replace_to(
-        lockfile, :gem_checks,
-        target: ActionView::RecordIdentifier.dom_id(gem_check),
-        partial: "gem_checks/gem_check",
-        locals: { gem_check: gem_check }
-      )
-    end
 
     def mark_lockfile_check_complete(lockfile_check)
       return if lockfile_check.gem_checks.where(status: "pending").exists?
 
       lockfile_check.update!(status: "complete")
-
-      Turbo::StreamsChannel.broadcast_replace_to(
-        lockfile_check.lockfile, :gem_checks,
-        target: ActionView::RecordIdentifier.dom_id(lockfile_check, :status),
-        partial: "lockfile_checks/status_badge",
-        locals: { lockfile_check: lockfile_check }
-      )
     end
   end
 end

--- a/app/views/gem_checks/_gem_check.html.erb
+++ b/app/views/gem_checks/_gem_check.html.erb
@@ -1,4 +1,4 @@
-<tr class="<%= gem_check_row_class(gem_check.result) %>">
+<tr id="<%= dom_id(gem_check) %>" class="<%= gem_check_row_class(gem_check.result) %>">
   <td><%= gem_check.gem_name %></td>
   <td><%= gem_check.locked_version || "missing" %></td>
   <td>
@@ -8,7 +8,7 @@
   </td>
   <td>
     <% if gem_check.earliest_compatible_version.present? %>
-      >= <%= gem_check.earliest_compatible_version %>
+      <%= gem_check.earliest_compatible_version %>
     <% elsif gem_check.skipped? && gem_check.source.present? %>
       <details style="max-width: 300px;">
         <summary class="text-muted">Source not accessible</summary>

--- a/app/views/gem_checks/_gem_check.html.erb
+++ b/app/views/gem_checks/_gem_check.html.erb
@@ -9,17 +9,17 @@
   <td>
     <% if gem_check.earliest_compatible_version.present? %>
       >= <%= gem_check.earliest_compatible_version %>
-    <% elsif gem_check.result == "skipped" && gem_check.source.present? %>
+    <% elsif gem_check.skipped? && gem_check.source.present? %>
       <details style="max-width: 300px;">
         <summary class="text-muted">Source not accessible</summary>
         <small class="text-muted d-block" style="overflow-wrap: break-word;"><%= gem_check.source %></small>
       </details>
-    <% elsif gem_check.result == "incompatible" && gem_check.error_message.present? %>
+    <% elsif gem_check.incompatible? && gem_check.error_message.present? %>
       <details style="max-width: 300px;">
         <summary class="text-danger">No compatible version</summary>
         <small class="text-muted d-block" style="overflow-wrap: break-word;"><%= gem_check.error_message %></small>
       </details>
-    <% elsif gem_check.result == "compatible" %>
+    <% elsif gem_check.compatible? %>
       &mdash;
     <% end %>
   </td>

--- a/app/views/gem_checks/_gem_check.html.erb
+++ b/app/views/gem_checks/_gem_check.html.erb
@@ -1,4 +1,4 @@
-<tr id="<%= dom_id(gem_check) %>" class="<%= gem_check_row_class(gem_check.result) %>">
+<tr class="<%= gem_check_row_class(gem_check.result) %>">
   <td><%= gem_check.gem_name %></td>
   <td><%= gem_check.locked_version || "missing" %></td>
   <td>

--- a/app/views/lockfile_checks/_status_badge.html.erb
+++ b/app/views/lockfile_checks/_status_badge.html.erb
@@ -1,9 +1,7 @@
-<span id="<%= dom_id(lockfile_check, :status) %>">
-  <% if lockfile_check.status == "complete" %>
-    <span class="badge bg-success">Complete</span>
-  <% elsif lockfile_check.status == "failed" %>
-    <span class="badge bg-danger">Failed</span>
-  <% else %>
-    <span class="badge bg-warning text-dark">Checking...</span>
-  <% end %>
-</span>
+<% if lockfile_check.status == "complete" %>
+  <span class="badge bg-success">Complete</span>
+<% elsif lockfile_check.status == "failed" %>
+  <span class="badge bg-danger">Failed</span>
+<% else %>
+  <span class="badge bg-warning text-dark">Checking...</span>
+<% end %>

--- a/app/views/lockfile_checks/_status_badge.html.erb
+++ b/app/views/lockfile_checks/_status_badge.html.erb
@@ -1,7 +1,9 @@
-<% if lockfile_check.complete? %>
-  <span class="badge bg-success">Complete</span>
-<% elsif lockfile_check.failed? %>
-  <span class="badge bg-danger">Failed</span>
-<% else %>
-  <span class="badge bg-warning text-dark">Checking...</span>
-<% end %>
+<span id="<%= dom_id(lockfile_check, :status) %>">
+  <% if lockfile_check.complete? %>
+    <span class="badge bg-success">Complete</span>
+  <% elsif lockfile_check.failed? %>
+    <span class="badge bg-danger">Failed</span>
+  <% else %>
+    <span class="badge bg-warning text-dark">Checking...</span>
+  <% end %>
+</span>

--- a/app/views/lockfile_checks/_status_badge.html.erb
+++ b/app/views/lockfile_checks/_status_badge.html.erb
@@ -1,6 +1,6 @@
-<% if lockfile_check.status == "complete" %>
+<% if lockfile_check.complete? %>
   <span class="badge bg-success">Complete</span>
-<% elsif lockfile_check.status == "failed" %>
+<% elsif lockfile_check.failed? %>
   <span class="badge bg-danger">Failed</span>
 <% else %>
   <span class="badge bg-warning text-dark">Checking...</span>

--- a/app/views/lockfiles/_checks.html.erb
+++ b/app/views/lockfiles/_checks.html.erb
@@ -1,0 +1,69 @@
+<div id="lockfile_checks">
+  <% lockfile.lockfile_checks.includes(:rails_release, :gem_checks).each do |lockfile_check| %>
+    <section class="mt-4">
+      <div class="row mb-3">
+        <div class="col-md-6 order-2 order-md-1">
+          <table class="table table-sm table-hover mb-0" style="cursor: pointer;">
+            <tbody>
+              <tr>
+                <th scope="row">Target Rails</th>
+                <td class="text-end"><%= lockfile_check.rails_release.version %></td>
+              </tr>
+              <tr>
+                <th scope="row">Ruby</th>
+                <td class="text-end"><%= lockfile_check.ruby_version %></td>
+              </tr>
+              <tr>
+                <th scope="row">Bundler</th>
+                <td class="text-end"><%= lockfile_check.bundler_version %></td>
+              </tr>
+              <tr>
+                <th scope="row">RubyGems</th>
+                <td class="text-end"><%= lockfile_check.rubygems_version %></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="col-md-6 order-1 order-md-2 d-flex align-items-center mb-3 mb-md-0">
+          <p class="text-muted small mb-0">
+            Ruby and Bundler come from the <code>Gemfile.lock</code> you provided,
+            unless the target Rails version requires a newer minimum, in which
+            case we use that minimum instead. RubyGems is derived from the chosen
+            Ruby version.
+          </p>
+        </div>
+      </div>
+
+      <div class="d-flex align-items-center gap-2 mb-3">
+        <h2 class="mb-0">Compatibility with Rails <%= lockfile_check.rails_release.version %></h2>
+        <%= render "lockfile_checks/status_badge", lockfile_check: lockfile_check %>
+      </div>
+
+      <% if lockfile_check.gem_checks.any? %>
+        <div class="table-responsive">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Gem</th>
+                <th>Locked Version</th>
+                <th>Result</th>
+                <th style="width: 30%;">Earliest Compatible</th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= render partial: "gem_checks/gem_check", collection: lockfile_check.gem_checks.order(:gem_name) %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
+
+  <% if lockfile.lockfile_checks.empty? %>
+    <section class="mt-4">
+      <div class="alert alert-info">
+        Results will appear here automatically as they are processed.
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/app/views/lockfiles/_checks.html.erb
+++ b/app/views/lockfiles/_checks.html.erb
@@ -36,7 +36,7 @@
 
       <div class="d-flex align-items-center gap-2 mb-3">
         <h2 class="mb-0">Compatibility with Rails <%= lockfile_check.rails_release.version %></h2>
-        <%= render "lockfile_checks/status_badge", lockfile_check: lockfile_check %>
+        <%= render partial: "lockfile_checks/status_badge", locals: { lockfile_check: lockfile_check } %>
       </div>
 
       <% if lockfile_check.gem_checks.any? %>

--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -10,73 +10,7 @@
 
 <%= turbo_stream_from @lockfile, :gem_checks %>
 
-<% @lockfile.lockfile_checks.each do |lockfile_check| %>
-  <section class="mt-4">
-    <div class="row mb-3">
-      <div class="col-md-6 order-2 order-md-1">
-        <table class="table table-sm table-hover mb-0" style="cursor: pointer;">
-          <tbody>
-            <tr>
-              <th scope="row">Target Rails</th>
-              <td class="text-end"><%= lockfile_check.rails_release.version %></td>
-            </tr>
-            <tr>
-              <th scope="row">Ruby</th>
-              <td class="text-end"><%= lockfile_check.ruby_version %></td>
-            </tr>
-            <tr>
-              <th scope="row">Bundler</th>
-              <td class="text-end"><%= lockfile_check.bundler_version %></td>
-            </tr>
-            <tr>
-              <th scope="row">RubyGems</th>
-              <td class="text-end"><%= lockfile_check.rubygems_version %></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div class="col-md-6 order-1 order-md-2 d-flex align-items-center mb-3 mb-md-0">
-        <p class="text-muted small mb-0">
-          Ruby and Bundler come from the <code>Gemfile.lock</code> you provided,
-          unless the target Rails version requires a newer minimum, in which
-          case we use that minimum instead. RubyGems is derived from the chosen
-          Ruby version.
-        </p>
-      </div>
-    </div>
-
-    <div class="d-flex align-items-center gap-2 mb-3">
-      <h2 class="mb-0">Compatibility with Rails <%= lockfile_check.rails_release.version %></h2>
-      <%= render "lockfile_checks/status_badge", lockfile_check: lockfile_check %>
-    </div>
-
-    <% if lockfile_check.gem_checks.any? %>
-      <div class="table-responsive">
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th>Gem</th>
-              <th>Locked Version</th>
-              <th>Result</th>
-              <th style="width: 30%;">Earliest Compatible</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= render partial: "gem_checks/gem_check", collection: lockfile_check.gem_checks.order(:gem_name) %>
-          </tbody>
-        </table>
-      </div>
-    <% end %>
-  </section>
-<% end %>
-
-<% if @lockfile.lockfile_checks.empty? %>
-  <section class="mt-4">
-    <div class="alert alert-info">
-      Results will appear here automatically as they are processed.
-    </div>
-  </section>
-<% end %>
+<%= render "lockfiles/checks", lockfile: @lockfile %>
 
 <div id="lockfile-content-modal" class="modal fade">
   <div class="modal-dialog modal-dialog-scrollable modal-lg">

--- a/app/views/lockfiles/show_new.html.erb
+++ b/app/views/lockfiles/show_new.html.erb
@@ -10,7 +10,7 @@
 
 <%= turbo_stream_from @lockfile, :gem_checks %>
 
-<%= render "lockfiles/checks", lockfile: @lockfile %>
+<%= render partial: "lockfiles/checks", locals: { lockfile: @lockfile } %>
 
 <div id="lockfile-content-modal" class="modal fade">
   <div class="modal-dialog modal-dialog-scrollable modal-lg">


### PR DESCRIPTION
Closes https://github.com/railsbump/app/issues/224

## What

Makes the lockfile check results page update live, so new check sections, gem rows, and the status badge appear without a manual reload.

## Why

The page subscribed to a Turbo stream, but every broadcast was a `broadcast_replace_to` aimed at DOM ids (`dom_id(gem_check)`, `dom_id(lockfile_check, :status)`) that did not exist on first load.
When the page rendered, the lockfile had no checks yet, so the loop produced no section, no rows, and no status badge.
The later replaces targeted missing nodes and silently no-op'd, leaving the page stuck on the empty-state until a manual reload.

This was the missing piece for the page to update on its own once checks are queued and processed.