### PR TITLE
Mark gem checks failed when resolution exhausts retries

### DIFF
--- a/app/helpers/gem_checks_helper.rb
+++ b/app/helpers/gem_checks_helper.rb
@@ -1,36 +1,41 @@
 module GemChecksHelper
   def gem_check_result_badge_class(gem_check)
-    return "bg-danger" if gem_check.failed?
-
-    case gem_check.result
-    when "compatible" then "bg-success"
-    when "upgrade_needed" then "bg-warning text-dark"
-    when "incompatible" then "bg-danger"
-    when "skipped" then "bg-light text-muted border"
+    case gem_check_display_state(gem_check)
+    when :failed then "bg-danger"
+    when :compatible then "bg-success"
+    when :upgrade_needed then "bg-warning text-dark"
+    when :incompatible then "bg-danger"
+    when :skipped then "bg-light text-muted border"
     else "bg-secondary"
     end
   end
 
   def gem_check_row_class(gem_check)
-    return "table-danger" if gem_check.failed?
-
-    case gem_check.result
-    when "compatible" then "table-success"
-    when "upgrade_needed" then "table-warning"
-    when "incompatible" then "table-danger"
+    case gem_check_display_state(gem_check)
+    when :failed, :incompatible then "table-danger"
+    when :compatible then "table-success"
+    when :upgrade_needed then "table-warning"
     else ""
     end
   end
 
   def gem_check_result_label(gem_check)
-    return "Failed" if gem_check.failed?
-
-    case gem_check.result
-    when "compatible" then "Compatible"
-    when "upgrade_needed" then "Upgrade Needed"
-    when "incompatible" then "Incompatible"
-    when "skipped" then "Skipped"
+    case gem_check_display_state(gem_check)
+    when :failed then "Failed"
+    when :compatible then "Compatible"
+    when :upgrade_needed then "Upgrade Needed"
+    when :incompatible then "Incompatible"
+    when :skipped then "Skipped"
     else "Pending"
     end
   end
+
+  private
+
+    # Collapses the two enums (status + result) into the single concept the
+    # row renders. failed lives on status; the verdicts live on result; a gem
+    # with no result yet is pending.
+    def gem_check_display_state(gem_check)
+      gem_check.failed? ? :failed : (gem_check.result&.to_sym || :pending)
+    end
 end

--- a/app/helpers/gem_checks_helper.rb
+++ b/app/helpers/gem_checks_helper.rb
@@ -1,6 +1,8 @@
 module GemChecksHelper
-  def gem_check_result_badge_class(result)
-    case result
+  def gem_check_result_badge_class(gem_check)
+    return "bg-danger" if gem_check.failed?
+
+    case gem_check.result
     when "compatible" then "bg-success"
     when "upgrade_needed" then "bg-warning text-dark"
     when "incompatible" then "bg-danger"
@@ -9,8 +11,10 @@ module GemChecksHelper
     end
   end
 
-  def gem_check_row_class(result)
-    case result
+  def gem_check_row_class(gem_check)
+    return "table-danger" if gem_check.failed?
+
+    case gem_check.result
     when "compatible" then "table-success"
     when "upgrade_needed" then "table-warning"
     when "incompatible" then "table-danger"
@@ -18,8 +22,10 @@ module GemChecksHelper
     end
   end
 
-  def gem_check_result_label(result)
-    case result
+  def gem_check_result_label(gem_check)
+    return "Failed" if gem_check.failed?
+
+    case gem_check.result
     when "compatible" then "Compatible"
     when "upgrade_needed" then "Upgrade Needed"
     when "incompatible" then "Incompatible"

--- a/app/helpers/gem_checks_helper.rb
+++ b/app/helpers/gem_checks_helper.rb
@@ -32,9 +32,6 @@ module GemChecksHelper
 
   private
 
-    # Collapses the two enums (status + result) into the single concept the
-    # row renders. failed lives on status; the verdicts live on result; a gem
-    # with no result yet is pending.
     def gem_check_display_state(gem_check)
       gem_check.failed? ? :failed : (gem_check.result&.to_sym || :pending)
     end

--- a/app/helpers/gem_checks_helper.rb
+++ b/app/helpers/gem_checks_helper.rb
@@ -1,31 +1,31 @@
 module GemChecksHelper
   def gem_check_result_badge_class(gem_check)
     case gem_check_display_state(gem_check)
-    when :failed then "bg-danger"
-    when :compatible then "bg-success"
-    when :upgrade_needed then "bg-warning text-dark"
-    when :incompatible then "bg-danger"
-    when :skipped then "bg-light text-muted border"
+    when "failed" then "bg-danger"
+    when "compatible" then "bg-success"
+    when "upgrade_needed" then "bg-warning text-dark"
+    when "incompatible" then "bg-danger"
+    when "skipped" then "bg-light text-muted border"
     else "bg-secondary"
     end
   end
 
   def gem_check_row_class(gem_check)
     case gem_check_display_state(gem_check)
-    when :failed, :incompatible then "table-danger"
-    when :compatible then "table-success"
-    when :upgrade_needed then "table-warning"
+    when "failed", "incompatible" then "table-danger"
+    when "compatible" then "table-success"
+    when "upgrade_needed" then "table-warning"
     else ""
     end
   end
 
   def gem_check_result_label(gem_check)
     case gem_check_display_state(gem_check)
-    when :failed then "Failed"
-    when :compatible then "Compatible"
-    when :upgrade_needed then "Upgrade Needed"
-    when :incompatible then "Incompatible"
-    when :skipped then "Skipped"
+    when "failed" then "Failed"
+    when "compatible" then "Compatible"
+    when "upgrade_needed" then "Upgrade Needed"
+    when "incompatible" then "Incompatible"
+    when "skipped" then "Skipped"
     else "Pending"
     end
   end
@@ -33,6 +33,6 @@ module GemChecksHelper
   private
 
     def gem_check_display_state(gem_check)
-      gem_check.failed? ? :failed : (gem_check.result&.to_sym || :pending)
+      gem_check.failed? ? "failed" : (gem_check.result || "pending")
     end
 end

--- a/app/models/gem_check.rb
+++ b/app/models/gem_check.rb
@@ -1,7 +1,7 @@
 class GemCheck < ApplicationRecord
   belongs_to :lockfile_check
 
-  enum :status, { pending: "pending", complete: "complete" }, validate: true
+  enum :status, { pending: "pending", complete: "complete", failed: "failed" }, validate: true
   enum :result, { compatible: "compatible", upgrade_needed: "upgrade_needed", incompatible: "incompatible", skipped: "skipped" }, validate: { allow_nil: true }
 
   validates :gem_name, presence: true

--- a/app/models/lockfile_check.rb
+++ b/app/models/lockfile_check.rb
@@ -3,7 +3,7 @@ class LockfileCheck < ApplicationRecord
   belongs_to :rails_release
   has_many :gem_checks, dependent: :destroy
 
-  enum :status, { pending: "pending", complete: "complete", failed: "failed" }, validate: true
+  enum :status, { pending: "pending", complete: "complete" }, validate: true
 
   def self.create_for!(lockfile:, rails_release:)
     runtime = TargetRuntime.new(lockfile: lockfile, rails_release: rails_release)

--- a/app/serializers/api/lockfile_serializer.rb
+++ b/app/serializers/api/lockfile_serializer.rb
@@ -17,7 +17,6 @@ module API
       def overall_status
         checks = @lockfile.lockfile_checks
         return "pending" if checks.empty? || checks.any?(&:pending?)
-        return "failed"  if checks.any?(&:failed?)
 
         "complete"
       end

--- a/app/services/checks/resolve_gem.rb
+++ b/app/services/checks/resolve_gem.rb
@@ -27,9 +27,6 @@ module Checks
       self.class.finalize(gem_check.lockfile_check)
     end
 
-    # Completes the lockfile check once no gem checks remain pending (failed
-    # gems count as terminal), then broadcasts the updated state. Shared by the
-    # success path and the retries-exhausted handler.
     def self.finalize(lockfile_check)
       if lockfile_check.pending? && lockfile_check.gem_checks.where(status: "pending").none?
         lockfile_check.update!(status: "complete")

--- a/app/services/checks/resolve_gem.rb
+++ b/app/services/checks/resolve_gem.rb
@@ -8,34 +8,34 @@ module Checks
 
     sidekiq_options retry: 3
 
-    # When all retries are exhausted, the gem could not be resolved. Mark the
-    # whole lockfile check failed and broadcast, so the page leaves "Checking..."
-    # and shows "Failed" instead of hanging on the spinner forever.
+    # When all retries are exhausted, the gem itself could not be resolved.
+    # Mark just that gem failed (the other gems' results are still valid) and
+    # finalize, so the lockfile check leaves "Checking..." once every gem has
+    # reached a terminal state.
     sidekiq_retries_exhausted do |job, _exception|
       gem_check = GemCheck.find_by(id: job["args"].first)
       next unless gem_check
 
-      lockfile_check = gem_check.lockfile_check
-      lockfile_check.failed!
-      lockfile_check.lockfile.broadcast_checks
+      gem_check.failed!
+      finalize(gem_check.lockfile_check)
     end
 
     def perform(gem_check_id)
       gem_check = GemCheck.find(gem_check_id)
       gem_check.perform!
 
-      lockfile_check = gem_check.lockfile_check
-      mark_lockfile_check_complete(lockfile_check)
-      lockfile_check.lockfile.broadcast_checks
+      self.class.finalize(gem_check.lockfile_check)
     end
 
-    private
+    # Completes the lockfile check once no gem checks remain pending (failed
+    # gems count as terminal), then broadcasts the updated state. Shared by the
+    # success path and the retries-exhausted handler.
+    def self.finalize(lockfile_check)
+      if lockfile_check.pending? && lockfile_check.gem_checks.where(status: "pending").none?
+        lockfile_check.update!(status: "complete")
+      end
 
-    def mark_lockfile_check_complete(lockfile_check)
-      return unless lockfile_check.pending?
-      return if lockfile_check.gem_checks.where(status: "pending").exists?
-
-      lockfile_check.update!(status: "complete")
+      lockfile_check.lockfile.broadcast_checks
     end
   end
 end

--- a/app/services/checks/resolve_gem.rb
+++ b/app/services/checks/resolve_gem.rb
@@ -6,6 +6,20 @@ module Checks
   class ResolveGem
     include Sidekiq::Job
 
+    sidekiq_options retry: 3
+
+    # When all retries are exhausted, the gem could not be resolved. Mark the
+    # whole lockfile check failed and broadcast, so the page leaves "Checking..."
+    # and shows "Failed" instead of hanging on the spinner forever.
+    sidekiq_retries_exhausted do |job, _exception|
+      gem_check = GemCheck.find_by(id: job["args"].first)
+      next unless gem_check
+
+      lockfile_check = gem_check.lockfile_check
+      lockfile_check.failed!
+      lockfile_check.lockfile.broadcast_checks
+    end
+
     def perform(gem_check_id)
       gem_check = GemCheck.find(gem_check_id)
       gem_check.perform!
@@ -18,6 +32,7 @@ module Checks
     private
 
     def mark_lockfile_check_complete(lockfile_check)
+      return unless lockfile_check.pending?
       return if lockfile_check.gem_checks.where(status: "pending").exists?
 
       lockfile_check.update!(status: "complete")

--- a/app/views/gem_checks/_gem_check.html.erb
+++ b/app/views/gem_checks/_gem_check.html.erb
@@ -1,10 +1,14 @@
-<tr class="<%= gem_check_row_class(gem_check.result) %>">
+<tr class="<%= gem_check.failed? ? "table-danger" : gem_check_row_class(gem_check.result) %>">
   <td><%= gem_check.gem_name %></td>
   <td><%= gem_check.locked_version || "missing" %></td>
   <td>
-    <span class="badge <%= gem_check_result_badge_class(gem_check.result) %>">
-      <%= gem_check_result_label(gem_check.result) %>
-    </span>
+    <% if gem_check.failed? %>
+      <span class="badge bg-danger">Failed</span>
+    <% else %>
+      <span class="badge <%= gem_check_result_badge_class(gem_check.result) %>">
+        <%= gem_check_result_label(gem_check.result) %>
+      </span>
+    <% end %>
   </td>
   <td>
     <% if gem_check.earliest_compatible_version.present? %>

--- a/app/views/gem_checks/_gem_check.html.erb
+++ b/app/views/gem_checks/_gem_check.html.erb
@@ -1,14 +1,10 @@
-<tr class="<%= gem_check.failed? ? "table-danger" : gem_check_row_class(gem_check.result) %>">
+<tr class="<%= gem_check_row_class(gem_check) %>">
   <td><%= gem_check.gem_name %></td>
   <td><%= gem_check.locked_version || "missing" %></td>
   <td>
-    <% if gem_check.failed? %>
-      <span class="badge bg-danger">Failed</span>
-    <% else %>
-      <span class="badge <%= gem_check_result_badge_class(gem_check.result) %>">
-        <%= gem_check_result_label(gem_check.result) %>
-      </span>
-    <% end %>
+    <span class="badge <%= gem_check_result_badge_class(gem_check) %>">
+      <%= gem_check_result_label(gem_check) %>
+    </span>
   </td>
   <td>
     <% if gem_check.earliest_compatible_version.present? %>

--- a/app/views/lockfile_checks/_status_badge.html.erb
+++ b/app/views/lockfile_checks/_status_badge.html.erb
@@ -1,7 +1,5 @@
 <% if lockfile_check.complete? %>
   <span class="badge bg-success">Complete</span>
-<% elsif lockfile_check.failed? %>
-  <span class="badge bg-danger">Failed</span>
 <% else %>
   <span class="badge bg-warning text-dark">Checking...</span>
 <% end %>

--- a/docs/api_check_lockfile.md
+++ b/docs/api_check_lockfile.md
@@ -70,21 +70,19 @@ Issues `GET /lockfiles/:slug` and pretty-prints:
 
 ### Status values
 
-Top-level `status` is one of:
+Top-level `status` (and each `lockfile_check.status`) is one of:
 
-- `"pending"` — the check is still running. Keep polling (honor
-  `retry_after_seconds` / the `Retry-After` header).
-- `"complete"` — every nested check resolved. Terminal, stop polling.
-- `"failed"` — a gem could not be resolved after the checker exhausted
-  its retries. Terminal, stop polling.
+- `"pending"` — work remains. Keep polling (honor `retry_after_seconds` /
+  the `Retry-After` header).
+- `"complete"` — every gem reached a terminal state. Terminal, stop polling.
 
-Treat both `"complete"` and `"failed"` as terminal: poll only while the
-status is `"pending"`.
-
-When the top-level status is `"failed"`, the offending `lockfile_check`
-carries `status: "failed"`; its unresolved `gem_check` may still report
-`status: "pending"`, since per-gem checks have no failure state of their
-own.
+Failure is tracked per gem, not per lockfile: each `gem_check.status` is
+`"pending"`, `"complete"`, or `"failed"`. A gem is marked `"failed"` when
+it could not be resolved after the checker exhausted its retries. The
+surrounding `lockfile_check` still becomes `"complete"` once every gem is
+terminal, so a completed check can contain individual `"failed"` gems
+alongside resolved ones. Inspect `gem_check.status` / `gem_check.result`
+for per-gem outcomes.
 
 ## Hitting a non-local environment
 

--- a/docs/api_check_lockfile.md
+++ b/docs/api_check_lockfile.md
@@ -68,8 +68,23 @@ Issues `GET /lockfiles/:slug` and pretty-prints:
 }
 ```
 
-Top-level `status` flips to `"complete"` once every nested
-`gem_check.status` is `"complete"`.
+### Status values
+
+Top-level `status` is one of:
+
+- `"pending"` — the check is still running. Keep polling (honor
+  `retry_after_seconds` / the `Retry-After` header).
+- `"complete"` — every nested check resolved. Terminal, stop polling.
+- `"failed"` — a gem could not be resolved after the checker exhausted
+  its retries. Terminal, stop polling.
+
+Treat both `"complete"` and `"failed"` as terminal: poll only while the
+status is `"pending"`.
+
+When the top-level status is `"failed"`, the offending `lockfile_check`
+carries `status: "failed"`; its unresolved `gem_check` may still report
+`status: "pending"`, since per-gem checks have no failure state of their
+own.
 
 ## Hitting a non-local environment
 

--- a/spec/controllers/api/lockfiles_controller_spec.rb
+++ b/spec/controllers/api/lockfiles_controller_spec.rb
@@ -153,22 +153,23 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
       expect(gc["result"]).to eq("compatible")
     end
 
-    it "returns status 'failed' when any lockfile_check has failed" do
+    it "reports a gem that could not be resolved as failed within a completed check" do
       lockfile = FactoryBot.create(:lockfile)
       rails_release = FactoryBot.create(:rails_release, version: "7.2")
-      lockfile_check = FactoryBot.create(:lockfile_check, lockfile: lockfile, rails_release: rails_release, status: "failed")
-      # The gem that could not be resolved stays pending: per-gem checks have
-      # no failure state, so only the parent lockfile_check is marked failed.
-      FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "puma", status: "pending")
+      lockfile_check = FactoryBot.create(:lockfile_check, lockfile: lockfile, rails_release: rails_release, status: "complete")
+      # Failure is per-gem: the check itself completes, the offending gem is failed.
+      FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "puma", status: "complete", result: "compatible")
+      FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "rack", status: "failed")
 
       get :show, params: { id: lockfile.slug }, as: :json
 
       expect(response).to have_http_status(:ok)
       json = JSON.parse(response.body)
-      expect(json["status"]).to eq("failed")
+      expect(json["status"]).to eq("complete")
       check = json["lockfile_checks"].first
-      expect(check["status"]).to eq("failed")
-      expect(check["gem_checks"].first["status"]).to eq("pending")
+      expect(check["status"]).to eq("complete")
+      statuses = check["gem_checks"].map { |gc| [gc["name"], gc["status"]] }.to_h
+      expect(statuses).to eq("puma" => "complete", "rack" => "failed")
     end
 
     it "returns 404 when slug is unknown" do

--- a/spec/controllers/api/lockfiles_controller_spec.rb
+++ b/spec/controllers/api/lockfiles_controller_spec.rb
@@ -156,12 +156,19 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
     it "returns status 'failed' when any lockfile_check has failed" do
       lockfile = FactoryBot.create(:lockfile)
       rails_release = FactoryBot.create(:rails_release, version: "7.2")
-      FactoryBot.create(:lockfile_check, lockfile: lockfile, rails_release: rails_release, status: "failed")
+      lockfile_check = FactoryBot.create(:lockfile_check, lockfile: lockfile, rails_release: rails_release, status: "failed")
+      # The gem that could not be resolved stays pending: per-gem checks have
+      # no failure state, so only the parent lockfile_check is marked failed.
+      FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "puma", status: "pending")
 
       get :show, params: { id: lockfile.slug }, as: :json
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)["status"]).to eq("failed")
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq("failed")
+      check = json["lockfile_checks"].first
+      expect(check["status"]).to eq("failed")
+      expect(check["gem_checks"].first["status"]).to eq("pending")
     end
 
     it "returns 404 when slug is unknown" do

--- a/spec/controllers/api/lockfiles_controller_spec.rb
+++ b/spec/controllers/api/lockfiles_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe API::LockfilesController, type: :controller, new_check_flow: true
       expect(gc["result"]).to eq("compatible")
     end
 
-    it "reports a gem that could not be resolved as failed within a completed check" do
+    it "keeps the check 'complete' while marking the unresolved gem 'failed'" do
       lockfile = FactoryBot.create(:lockfile)
       rails_release = FactoryBot.create(:rails_release, version: "7.2")
       lockfile_check = FactoryBot.create(:lockfile_check, lockfile: lockfile, rails_release: rails_release, status: "complete")

--- a/spec/services/checks/resolve_gem_spec.rb
+++ b/spec/services/checks/resolve_gem_spec.rb
@@ -47,22 +47,24 @@ RSpec.describe Checks::ResolveGem, type: :job, new_check_flow: true do
       )
     end
 
-    it "marks the lockfile check failed" do
+    it "marks the unresolved gem check failed" do
       run_exhausted
 
-      expect(lockfile_check.reload.status).to eq("failed")
+      expect(gem_check.reload.status).to eq("failed")
     end
 
-    it "does not flip the failed check back to complete when a later gem resolves" do
+    it "completes the lockfile check once the failed gem is its last pending one" do
       run_exhausted
 
-      allow_any_instance_of(GemCheck).to receive(:perform!) do |gc|
-        gc.update!(status: "complete", result: "compatible")
-      end
-      other = FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "rack", status: "pending")
-      described_class.new.perform(other.id)
+      expect(lockfile_check.reload.status).to eq("complete")
+    end
 
-      expect(lockfile_check.reload.status).to eq("failed")
+    it "leaves the lockfile check pending while other gem checks are still pending" do
+      FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "rack", status: "pending")
+
+      run_exhausted
+
+      expect(lockfile_check.reload.status).to eq("pending")
     end
 
     it "broadcasts the failure so the page leaves the spinner" do

--- a/spec/services/checks/resolve_gem_spec.rb
+++ b/spec/services/checks/resolve_gem_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Checks::ResolveGem, type: :job, new_check_flow: true do
       expect(gem_check.reload.status).to eq("failed")
     end
 
-    it "completes the lockfile check once the failed gem is its last pending one" do
+    it "completes the lockfile check when the failed gem was the last one pending" do
       run_exhausted
 
       expect(lockfile_check.reload.status).to eq("complete")

--- a/spec/services/checks/resolve_gem_spec.rb
+++ b/spec/services/checks/resolve_gem_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Checks::ResolveGem, type: :job, new_check_flow: true do
+  let(:lockfile_check) { FactoryBot.create(:lockfile_check) }
+  let(:gem_check) { FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "puma", status: "pending") }
+
+  describe "#perform" do
+    before do
+      allow_any_instance_of(GemCheck).to receive(:perform!) do |gc|
+        gc.update!(status: "complete", result: "compatible")
+      end
+    end
+
+    it "resolves the gem check" do
+      described_class.new.perform(gem_check.id)
+
+      expect(gem_check.reload.status).to eq("complete")
+    end
+
+    it "marks the lockfile check complete once no gem checks remain pending" do
+      described_class.new.perform(gem_check.id)
+
+      expect(lockfile_check.reload.status).to eq("complete")
+    end
+
+    it "leaves the lockfile check pending while other gem checks are still pending" do
+      FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "rack", status: "pending")
+
+      described_class.new.perform(gem_check.id)
+
+      expect(lockfile_check.reload.status).to eq("pending")
+    end
+
+    it "broadcasts the updated checks to the lockfile" do
+      expect_any_instance_of(Lockfile).to receive(:broadcast_checks)
+
+      described_class.new.perform(gem_check.id)
+    end
+  end
+
+  describe "retries exhausted" do
+    subject(:run_exhausted) do
+      described_class.sidekiq_retries_exhausted_block.call(
+        { "args" => [gem_check.id] }, StandardError.new("boom")
+      )
+    end
+
+    it "marks the lockfile check failed" do
+      run_exhausted
+
+      expect(lockfile_check.reload.status).to eq("failed")
+    end
+
+    it "broadcasts the failure so the page leaves the spinner" do
+      expect_any_instance_of(Lockfile).to receive(:broadcast_checks)
+
+      run_exhausted
+    end
+
+    it "does nothing when the gem check no longer exists" do
+      gem_check.destroy
+
+      expect { run_exhausted }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/checks/resolve_gem_spec.rb
+++ b/spec/services/checks/resolve_gem_spec.rb
@@ -31,10 +31,12 @@ RSpec.describe Checks::ResolveGem, type: :job, new_check_flow: true do
       expect(lockfile_check.reload.status).to eq("pending")
     end
 
-    it "broadcasts the updated checks to the lockfile" do
-      expect_any_instance_of(Lockfile).to receive(:broadcast_checks)
+    it "broadcasts the updated checks to the lockfile's stream" do
+      stream = "#{lockfile_check.lockfile.to_gid_param}:gem_checks"
 
-      described_class.new.perform(gem_check.id)
+      expect do
+        described_class.new.perform(gem_check.id)
+      end.to have_broadcasted_to(stream)
     end
   end
 
@@ -51,10 +53,22 @@ RSpec.describe Checks::ResolveGem, type: :job, new_check_flow: true do
       expect(lockfile_check.reload.status).to eq("failed")
     end
 
-    it "broadcasts the failure so the page leaves the spinner" do
-      expect_any_instance_of(Lockfile).to receive(:broadcast_checks)
-
+    it "does not flip the failed check back to complete when a later gem resolves" do
       run_exhausted
+
+      allow_any_instance_of(GemCheck).to receive(:perform!) do |gc|
+        gc.update!(status: "complete", result: "compatible")
+      end
+      other = FactoryBot.create(:gem_check, lockfile_check: lockfile_check, gem_name: "rack", status: "pending")
+      described_class.new.perform(other.id)
+
+      expect(lockfile_check.reload.status).to eq("failed")
+    end
+
+    it "broadcasts the failure so the page leaves the spinner" do
+      stream = "#{lockfile_check.lockfile.to_gid_param}:gem_checks"
+
+      expect { run_exhausted }.to have_broadcasted_to(stream)
     end
 
     it "does nothing when the gem check no longer exists" do


### PR DESCRIPTION
Closes #230 

## What

Gives gem checks a terminal `failed` state when a gem cannot be resolved, so a stuck gem no longer hangs the whole lockfile check on "Checking..."

## Why

Each gem is resolved by its own independent `Checks::ResolveGem` job. If `GemCheck#perform!` raised (resolver subprocess crash, network, OOM), the exception bubbled up and Sidekiq retried on its default schedule (25 times over ~21 days). The lockfile check stayed `pending` the whole time, so the page sat on the "Checking..." spinner and `GET /api/lockfiles/:slug` returned `pending` indefinitely.

Production confirms the hang is real: of 15 pending `lockfile_checks`, 13 had exactly 2 gems stuck pending for 19–39 days while the rest resolved fine. Failing the *whole* check would have hidden those resolved results, so failure belongs at the gem level.

## How

- On `sidekiq_retries_exhausted`, mark just the offending gem `failed`, then finalize: the lockfile check transitions to `complete` once no gem remains pending (a failed gem is terminal). Shared `finalize` is used by both the success path and the exhausted handler, and always broadcasts.
- UI: the failed gem renders a red "Failed" row; the section badge stays "Complete".

## Follow-ups

- Per-result summary: counts of compatible / incompatible / skipped / failed gems (and an optional "Completed with N errors" label).

## Stacking

Stacked on #228 (live-render). Depends on `Lockfile#broadcast_checks` from there, so merge #228 first.
