### PR TITLE
Mark LockfileCheck as completed if all gems are skipped

### DIFF
--- a/app/models/lockfile_check.rb
+++ b/app/models/lockfile_check.rb
@@ -38,6 +38,10 @@ class LockfileCheck < ApplicationRecord
 
   def enqueue_gem_checks
     ids = gem_checks.where(status: "pending").pluck(:id)
-    Checks::ResolveGem.perform_bulk(ids.map { [_1] }) if ids.any?
+    if ids.any?
+      Checks::ResolveGem.perform_bulk(ids.map { [_1] })
+    else
+      complete!
+    end
   end
 end

--- a/spec/models/lockfile_check_spec.rb
+++ b/spec/models/lockfile_check_spec.rb
@@ -110,5 +110,18 @@ RSpec.describe LockfileCheck, type: :model, new_check_flow: true do
 
       expect(Checks::ResolveGem).not_to have_received(:perform_bulk)
     end
+
+    it "sets status to completed if there are no gem_checks to enqueue" do
+      lockfile_check = FactoryBot.create(:lockfile_check)
+      FactoryBot.create(:gem_check,
+        lockfile_check: lockfile_check,
+        gem_name: "puma",
+        status: "complete",
+        result: "skipped")
+
+      lockfile_check.enqueue_gem_checks
+
+      expect(lockfile_check).to be_complete
+    end
   end
 end


### PR DESCRIPTION
Solves #231 

When processing a lockfile, if all the gems are skipped (either source is not valid or version is not defined), no GemCheck background job was added to the queue, so nothing was getting processed and the LockfileCheck object was never updated.

Now, if there are no GemChecks to enqueue, we change the status to `complete` right away.

I used this lockfile to test this (it's the lockfile of this project but using the gems.coop source)

[Gemfile.lock.zip](https://github.com/user-attachments/files/28801642/Gemfile.lock.zip)
